### PR TITLE
Change gitleaks hook to use docker version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,5 +33,5 @@ repos:
   - repo: https://github.com/gitleaks/gitleaks
     rev: v8.18.0
     hooks:
-      - id: gitleaks
+      - id: gitleaks-docker
         stages: [manual, push]


### PR DESCRIPTION
Easier for devs working with https://github.com/oamg/rhc-worker-script to use the hook, worker requires 1.16 but gitleaks 1.17