### PR TITLE
Update required files for pre-analysis

### DIFF
--- a/scripts/preconversion_assessment_script.py
+++ b/scripts/preconversion_assessment_script.py
@@ -383,10 +383,6 @@ def main():
             host="https://www.redhat.com/security/data/fd431d51.txt",
         ),
         RequiredFile(
-            path="/etc/rhsm/ca/redhat-uep.pem",
-            host="https://ftp.redhat.com/redhat/convert2rhel/redhat-uep.pem",
-        ),
-        RequiredFile(
             path="/etc/yum.repos.d/convert2rhel.repo",
             host="https://ftp.redhat.com/redhat/convert2rhel/7/convert2rhel.repo",
         ),


### PR DESCRIPTION
Convert2RHEL does not need the redhat-uep.pem certificate anymore, as it was moved to a new domain that does not require downloading the Red Hat's self signed SSL cert, thus, deprecating that from the list of required files to download and check.