### PR TITLE
Add message to the OutputCollector exception

### DIFF
--- a/scripts/preconversion_assessment_script.py
+++ b/scripts/preconversion_assessment_script.py
@@ -36,9 +36,9 @@ class RequiredFile(object):
 class ProcessError(Exception):
     """Custom exception to report errors during setup and run of conver2rhel"""
 
-    def __init__(self, message):
-        super(ProcessError, self).__init__(message)
-        self.message = message
+    def __init__(self, report):
+        super(ProcessError, self).__init__(report)
+        self.report = report
 
 
 class OutputCollector(object):
@@ -100,7 +100,7 @@ def gather_json_report():
 
     if not data:
         raise ProcessError(
-            message="The file '%s' doesn't contain any JSON data in it."
+            report="The file '%s' doesn't contain any JSON data in it."
             % C2R_REPORT_FILE
         )
 
@@ -152,7 +152,7 @@ def setup_convert2rhel(required_files):
                 != required_file.sha512_on_system.hexdigest()
             ):
                 raise ProcessError(
-                    message="File '%s' present on the system does not match the one downloaded. Stopping the execution."
+                    report="File '%s' present on the system does not match the one downloaded. Stopping the execution."
                     % required_file.path
                 )
         else:
@@ -213,14 +213,14 @@ def install_convert2rhel():
     )
     if returncode:
         raise ProcessError(
-            message="Installing convert2rhel with yum exited with code '%s' and output: %s."
+            report="Installing convert2rhel with yum exited with code '%s' and output: %s."
             % (returncode, output.rstrip("\n"))
         )
 
     output, returncode = run_subprocess(["yum", "update", "convert2rhel", "-y"])
     if returncode:
         raise ProcessError(
-            message="Updating convert2rhel with yum exited with code '%s' and output: %s."
+            report="Updating convert2rhel with yum exited with code '%s' and output: %s."
             % (returncode, output.rstrip("\n"))
         )
 
@@ -240,7 +240,7 @@ def run_convert2rhel():
     _, returncode = run_subprocess(["/usr/bin/convert2rhel", "analyze", "-y"], env=env)
     if returncode:
         raise ProcessError(
-            message="convert2rhel execution exited with code '%s'." % returncode
+            report="convert2rhel execution exited with code '%s'." % returncode
         )
 
 
@@ -409,11 +409,11 @@ def main():
         output.entries = transform_raw_data(data)
         print("Pre-conversion assessment script finish successfully!")
     except ProcessError as exception:
-        print(exception.message)
+        print(exception.report)
         output = OutputCollector(
             status="ERROR",
             message="An error occurred. Expand the row for more details.",
-            report=exception.message,
+            report=exception.report,
         )
     except Exception as exception:
         print(str(exception))

--- a/scripts/preconversion_assessment_script.py
+++ b/scripts/preconversion_assessment_script.py
@@ -410,10 +410,18 @@ def main():
         print("Pre-conversion assessment script finish successfully!")
     except ProcessError as exception:
         print(exception.message)
-        output = OutputCollector(status="ERROR", report=exception.message)
+        output = OutputCollector(
+            status="ERROR",
+            message="An error occurred. Expand the row for more details.",
+            report=exception.message,
+        )
     except Exception as exception:
         print(str(exception))
-        output = OutputCollector(status="ERROR", report=str(exception))
+        output = OutputCollector(
+            status="ERROR",
+            message="An error occurred. Expand the row for more details.",
+            report=str(exception),
+        )
     finally:
         print("Cleaning up modifications to the system.")
         cleanup(required_files)

--- a/tests/preconversion_assessment/test_gather_report.py
+++ b/tests/preconversion_assessment/test_gather_report.py
@@ -39,6 +39,7 @@ def test_gather_json_report_no_content(tmpdir):
     with patch("scripts.preconversion_assessment_script.C2R_REPORT_FILE", file):
         with pytest.raises(
             ProcessError,
-            match="The file '%s' doesn't contain any JSON data in it." % file,
+            match="The convert2rhel analysis report file '%s' does not contain any JSON data in it."
+            % file,
         ):
             gather_json_report()

--- a/tests/preconversion_assessment/test_main.py
+++ b/tests/preconversion_assessment/test_main.py
@@ -49,7 +49,7 @@ def test_main_success(
 @patch("scripts.preconversion_assessment_script.verify_required_files_are_present", side_effect=Mock())
 @patch("scripts.preconversion_assessment_script.setup_convert2rhel", side_effect=Mock())
 @patch("scripts.preconversion_assessment_script.install_convert2rhel", side_effect=Mock())
-@patch("scripts.preconversion_assessment_script.run_convert2rhel", side_effect=ProcessError("Process error"))
+@patch("scripts.preconversion_assessment_script.run_convert2rhel", side_effect=ProcessError("test", "Process error"))
 @patch("scripts.preconversion_assessment_script.find_highest_report_level", side_effect=Mock(return_value=["SUCCESS"]))
 @patch("scripts.preconversion_assessment_script.gather_textual_report", side_effect=Mock(return_value=""))
 @patch("scripts.preconversion_assessment_script.generate_report_message", side_effect=Mock(return_value=""))


### PR DESCRIPTION
Add a generic message to the OutputCollector output to give some information in the Insights UI about what happened. The user will have a better understanding about what went wrong because of the `report` key.

Related: https://issues.redhat.com/browse/HMS-2627