### PR TITLE
Add output of failed convert2rhel command to script report field 

### DIFF
--- a/scripts/conversion_script.py
+++ b/scripts/conversion_script.py
@@ -212,7 +212,7 @@ def run_subprocess(cmd, print_cmd=True, env=None):
     password in plain text.
 
     The cmd is specified as a list starting with the command and followed by a
-    list of arguments. Example: ["yum", "install", "<package>"]
+    list of arguments. Example: ["/usr/bin/yum", "install", "<package>"]
     """
     # This check is here because we passed in strings in the past and changed
     # to a list for security hardening.  Remove this once everyone is
@@ -242,7 +242,7 @@ def install_convert2rhel():
     """Install the convert2rhel tool to the system."""
     print("Installing & updating Convert2RHEL package.")
     output, returncode = run_subprocess(
-        ["yum", "install", "convert2rhel", "-y"],
+        ["/usr/bin/yum", "install", "convert2rhel", "-y"],
     )
     if returncode:
         raise ProcessError(
@@ -251,7 +251,7 @@ def install_convert2rhel():
             % (returncode, output.rstrip("\n")),
         )
 
-    output, returncode = run_subprocess(["yum", "update", "convert2rhel", "-y"])
+    output, returncode = run_subprocess(["/usr/bin/yum", "update", "convert2rhel", "-y"])
     if returncode:
         raise ProcessError(
             message="Failed to update convert2rhel RPM.",

--- a/scripts/conversion_script.py
+++ b/scripts/conversion_script.py
@@ -272,14 +272,15 @@ def run_convert2rhel():
             "RHC_WORKER_CONVERT2RHEL_DISABLE_TELEMETRY"
         ]
 
-    _, returncode = run_subprocess(["/usr/bin/convert2rhel", "-y"], env=env)
+    output, returncode = run_subprocess(["/usr/bin/convert2rhel", "-y"], env=env)
     if returncode:
         raise ProcessError(
             message=(
                 "An error occurred during the conversion execution. For details, refer to "
                 "the convert2rhel log file on the host at /var/log/convert2rhel/convert2rhel.log"
             ),
-            report="convert2rhel execution exited with code '%s'." % returncode,
+            report="convert2rhel execution exited with code '%s'and output: %s."
+            % (returncode, output.rstrip("\n")),
         )
 
 
@@ -418,9 +419,9 @@ def update_insights_inventory():
 
     if returncode:
         raise ProcessError(
-            message="Failed to update Insights Inventory by registering the system again. See output the following output: %s"
-            % output,
-            report="insights-client execution exited with code '%s'." % returncode,
+            message="Failed to update Insights Inventory by registering the system again.",
+            report="insights-client execution exited with code '%s' and output: %s."
+            % (returncode, output.rstrip("\n")),
         )
 
     print("System registered with insights-client successfully.")

--- a/scripts/conversion_script.py
+++ b/scripts/conversion_script.py
@@ -251,7 +251,9 @@ def install_convert2rhel():
             % (returncode, output.rstrip("\n")),
         )
 
-    output, returncode = run_subprocess(["/usr/bin/yum", "update", "convert2rhel", "-y"])
+    output, returncode = run_subprocess(
+        ["/usr/bin/yum", "update", "convert2rhel", "-y"]
+    )
     if returncode:
         raise ProcessError(
             message="Failed to update convert2rhel RPM.",

--- a/scripts/preconversion_assessment_script.py
+++ b/scripts/preconversion_assessment_script.py
@@ -209,7 +209,7 @@ def run_subprocess(cmd, print_cmd=True, env=None):
     password in plain text.
 
     The cmd is specified as a list starting with the command and followed by a
-    list of arguments. Example: ["yum", "install", "<package>"]
+    list of arguments. Example: ["/usr/bin/yum", "install", "<package>"]
     """
     # This check is here because we passed in strings in the past and changed
     # to a list for security hardening.  Remove this once everyone is
@@ -239,7 +239,7 @@ def install_convert2rhel():
     """Install the convert2rhel tool to the system."""
     print("Installing & updating Convert2RHEL package.")
     output, returncode = run_subprocess(
-        ["yum", "install", "convert2rhel", "-y"],
+        ["/usr/bin/yum", "install", "convert2rhel", "-y"],
     )
     if returncode:
         raise ProcessError(
@@ -248,7 +248,7 @@ def install_convert2rhel():
             % (returncode, output.rstrip("\n")),
         )
 
-    output, returncode = run_subprocess(["yum", "update", "convert2rhel", "-y"])
+    output, returncode = run_subprocess(["/usr/bin/yum", "update", "convert2rhel", "-y"])
     if returncode:
         raise ProcessError(
             message="Failed to update convert2rhel RPM.",

--- a/scripts/preconversion_assessment_script.py
+++ b/scripts/preconversion_assessment_script.py
@@ -269,14 +269,17 @@ def run_convert2rhel():
             "RHC_WORKER_CONVERT2RHEL_DISABLE_TELEMETRY"
         ]
 
-    output, returncode = run_subprocess(["/usr/bin/convert2rhel", "analyze", "-y"], env=env)
+    output, returncode = run_subprocess(
+        ["/usr/bin/convert2rhel", "analyze", "-y"], env=env
+    )
     if returncode:
         raise ProcessError(
             message=(
                 "An error occurred during the pre-conversion analysis. "
                 "For details, refer to the convert2rhel log file on the host at /var/log/convert2rhel/convert2rhel.log"
             ),
-            report="convert2rhel execution exited with code '%s' and output: %s." % (returncode, output.rstrip("\n"))
+            report="convert2rhel execution exited with code '%s' and output: %s."
+            % (returncode, output.rstrip("\n")),
         )
 
 

--- a/scripts/preconversion_assessment_script.py
+++ b/scripts/preconversion_assessment_script.py
@@ -248,7 +248,9 @@ def install_convert2rhel():
             % (returncode, output.rstrip("\n")),
         )
 
-    output, returncode = run_subprocess(["/usr/bin/yum", "update", "convert2rhel", "-y"])
+    output, returncode = run_subprocess(
+        ["/usr/bin/yum", "update", "convert2rhel", "-y"]
+    )
     if returncode:
         raise ProcessError(
             message="Failed to update convert2rhel RPM.",

--- a/scripts/preconversion_assessment_script.py
+++ b/scripts/preconversion_assessment_script.py
@@ -269,14 +269,14 @@ def run_convert2rhel():
             "RHC_WORKER_CONVERT2RHEL_DISABLE_TELEMETRY"
         ]
 
-    _, returncode = run_subprocess(["/usr/bin/convert2rhel", "analyze", "-y"], env=env)
+    output, returncode = run_subprocess(["/usr/bin/convert2rhel", "analyze", "-y"], env=env)
     if returncode:
         raise ProcessError(
             message=(
                 "An error occurred during the pre-conversion analysis. "
                 "For details, refer to the convert2rhel log file on the host at /var/log/convert2rhel/convert2rhel.log"
             ),
-            report="convert2rhel execution exited with code '%s'." % returncode,
+            report="convert2rhel execution exited with code '%s' and output: %s." % (returncode, output.rstrip("\n"))
         )
 
 

--- a/tests/conversion_script/test_install.py
+++ b/tests/conversion_script/test_install.py
@@ -16,8 +16,8 @@ def test_install_convert2rhel(subprocess_mock):
         install_convert2rhel()
 
     expected_calls = [
-        ["yum", "install", "convert2rhel", "-y"],
-        ["yum", "update", "convert2rhel", "-y"],
+        ["/usr/bin/yum", "install", "convert2rhel", "-y"],
+        ["/usr/bin/yum", "update", "convert2rhel", "-y"],
     ]
 
     assert mock_run_subprocess.call_args_list == [call(args) for args in expected_calls]
@@ -34,7 +34,7 @@ def test_install_convert2rhel_raise_exception():
         ):
             install_convert2rhel()
 
-    expected_calls = [["yum", "install", "convert2rhel", "-y"]]
+    expected_calls = [["/usr/bin/yum", "install", "convert2rhel", "-y"]]
 
     assert mock_run_subprocess.call_args_list == [call(args) for args in expected_calls]
 
@@ -51,8 +51,8 @@ def test_update_convert2rhel_raise_exception():
             install_convert2rhel()
 
     expected_calls = [
-        ["yum", "install", "convert2rhel", "-y"],
-        ["yum", "update", "convert2rhel", "-y"],
+        ["/usr/bin/yum", "install", "convert2rhel", "-y"],
+        ["/usr/bin/yum", "update", "convert2rhel", "-y"],
     ]
 
     assert mock_run_subprocess.call_args_list == [call(args) for args in expected_calls]

--- a/tests/preconversion_assessment/test_install.py
+++ b/tests/preconversion_assessment/test_install.py
@@ -16,8 +16,8 @@ def test_install_convert2rhel(subprocess_mock):
         install_convert2rhel()
 
     expected_calls = [
-        ["yum", "install", "convert2rhel", "-y"],
-        ["yum", "update", "convert2rhel", "-y"],
+        ["/usr/bin/yum", "install", "convert2rhel", "-y"],
+        ["/usr/bin/yum", "update", "convert2rhel", "-y"],
     ]
 
     assert mock_run_subprocess.call_args_list == [call(args) for args in expected_calls]
@@ -34,7 +34,7 @@ def test_install_convert2rhel_raise_exception():
         ):
             install_convert2rhel()
 
-    expected_calls = [["yum", "install", "convert2rhel", "-y"]]
+    expected_calls = [["/usr/bin/yum", "install", "convert2rhel", "-y"]]
 
     assert mock_run_subprocess.call_args_list == [call(args) for args in expected_calls]
 
@@ -51,8 +51,8 @@ def test_update_convert2rhel_raise_exception():
             install_convert2rhel()
 
     expected_calls = [
-        ["yum", "install", "convert2rhel", "-y"],
-        ["yum", "update", "convert2rhel", "-y"],
+        ["/usr/bin/yum", "install", "convert2rhel", "-y"],
+        ["/usr/bin/yum", "update", "convert2rhel", "-y"],
     ]
 
     assert mock_run_subprocess.call_args_list == [call(args) for args in expected_calls]


### PR DESCRIPTION
Related to [HMS-2905](https://issues.redhat.com/browse/HMS-2905)

All raised ProcessErrorr right now have output attached to it.

It's up to discussion if we want to include all output or just some part of it, but since the wording can vary from error to error, parse everything could be safest and sanest option (we can talk about UI changes to have some expandable section - like show more, in cases of long reports - definitely achievable)