### PR TITLE
Add script inhibitor for custom/modified c2r ini file

### DIFF
--- a/scripts/conversion_script.py
+++ b/scripts/conversion_script.py
@@ -83,6 +83,59 @@ class OutputCollector(object):
         }
 
 
+def _check_ini_file_modified():
+    rpm_va_output, ini_file_not_modified = run_subprocess(
+        ["/usr/bin/rpm", "-Va", "convert2rhel"]
+    )
+
+    # No modifications at all
+    if not ini_file_not_modified:
+        return False
+
+    lines = rpm_va_output.strip().split("\n")
+    for line in lines:
+        line = line.strip().split()
+        status = line[0].replace(".", "").replace("?", "")
+        path = line[-1]
+
+        default_ini_modified = path == "/etc/convert2rhel.ini"
+        md5_hash_mismatch = "5" in status
+
+        if default_ini_modified and md5_hash_mismatch:
+            return True
+    return False
+
+
+def check_convert2rhel_inhibitors_before_run():
+    """
+    Conditions that must be True in order to run convert2rhel command.
+    """
+    default_ini_path = "/etc/convert2rhel.ini"
+    custom_ini_path = os.path.expanduser("~/.convert2rhel.ini")
+
+    if os.path.exists(custom_ini_path):
+        raise ProcessError(
+            message="Custom %s was found." % custom_ini_path,
+            report=(
+                "Remove the %s file by running "
+                "'rm -f %s' before running the Task again."
+            )
+            % (custom_ini_path, custom_ini_path),
+        )
+
+    if _check_ini_file_modified():
+        raise ProcessError(
+            message="According to 'rpm -Va' command %s was modified."
+            % default_ini_path,
+            report=(
+                "Either remove the %s file by running "
+                "'rm -f %s' or uninstall convert2rhel by running "
+                "'yum remove convert2rhel' before running the Task again."
+            )
+            % (default_ini_path, default_ini_path),
+        )
+
+
 def find_highest_report_level(actions):
     """
     Gather status codes from messages and result. We are not seeking for
@@ -283,7 +336,7 @@ def run_convert2rhel():
     """
     Run the convert2rhel tool assigning the correct environment variables.
     """
-    print("Running Convert2RHEL Analysis")
+    print("Running Convert2RHEL Conversion")
     env = {"PATH": os.environ["PATH"]}
 
     if "RHC_WORKER_CONVERT2RHEL_DISABLE_TELEMETRY" in os.environ:
@@ -475,6 +528,7 @@ def main():
     try:
         # Setup Convert2RHEL to be executed.
         setup_convert2rhel(required_files)
+        check_convert2rhel_inhibitors_before_run()
         installed, transaction_id = install_convert2rhel()
         if installed:
             YUM_TRANSACTIONS_TO_UNDO.add(transaction_id)

--- a/tests/conversion_script/test_check_ini_file_modified.py
+++ b/tests/conversion_script/test_check_ini_file_modified.py
@@ -1,0 +1,30 @@
+from mock import patch
+
+from scripts.conversion_script import _check_ini_file_modified
+
+
+@patch(
+    "scripts.conversion_script.run_subprocess",
+    return_value=("S.5....T  c /etc/convert2rhel.ini\n", True),
+)
+def test_check_ini_file_modified(mock_rpm_va):
+    result = _check_ini_file_modified()
+    assert result
+    mock_rpm_va.assert_called_once()
+
+
+@patch(
+    "scripts.conversion_script.run_subprocess",
+    return_value=("S.5....T  c /foo/bar\n", True),
+)
+def test_check_ini_file_not_modified(mock_rpm_va):
+    result = _check_ini_file_modified()
+    assert not result
+    mock_rpm_va.assert_called_once()
+
+
+@patch("scripts.conversion_script.run_subprocess", return_value=("", False))
+def test_check_ini_file_no_changes(mock_rpm_va):
+    result = _check_ini_file_modified()
+    assert not result
+    mock_rpm_va.assert_called_once()

--- a/tests/preconversion_assessment/test_check_ini_file_modified.py
+++ b/tests/preconversion_assessment/test_check_ini_file_modified.py
@@ -1,0 +1,32 @@
+from mock import patch
+
+from scripts.preconversion_assessment_script import _check_ini_file_modified
+
+
+@patch(
+    "scripts.preconversion_assessment_script.run_subprocess",
+    return_value=("S.5....T  c /etc/convert2rhel.ini\n", True),
+)
+def test_check_ini_file_modified(mock_rpm_va):
+    result = _check_ini_file_modified()
+    assert result
+    mock_rpm_va.assert_called_once()
+
+
+@patch(
+    "scripts.preconversion_assessment_script.run_subprocess",
+    return_value=("S.5....T  c /foo/bar\n", True),
+)
+def test_check_ini_file_not_modified(mock_rpm_va):
+    result = _check_ini_file_modified()
+    assert not result
+    mock_rpm_va.assert_called_once()
+
+
+@patch(
+    "scripts.preconversion_assessment_script.run_subprocess", return_value=("", False)
+)
+def test_check_ini_file_no_changes(mock_rpm_va):
+    result = _check_ini_file_modified()
+    assert not result
+    mock_rpm_va.assert_called_once()

--- a/tests/preconversion_assessment/test_main.py
+++ b/tests/preconversion_assessment/test_main.py
@@ -9,6 +9,7 @@ from scripts.preconversion_assessment_script import main, ProcessError
 @patch("scripts.preconversion_assessment_script.gather_json_report", side_effect=[{"actions": []}])
 @patch("scripts.preconversion_assessment_script.setup_convert2rhel", side_effect=Mock())
 @patch("scripts.preconversion_assessment_script.install_convert2rhel", return_value=(False, 1))
+@patch("scripts.preconversion_assessment_script.check_convert2rhel_inhibitors_before_run", return_value=("", 0))
 @patch("scripts.preconversion_assessment_script.run_convert2rhel", side_effect=Mock())
 @patch("scripts.preconversion_assessment_script.find_highest_report_level", side_effect=Mock(return_value=["SUCCESS"]))
 @patch("scripts.preconversion_assessment_script.gather_textual_report", side_effect=Mock(return_value=""))
@@ -23,6 +24,7 @@ def test_main_success(
     mock_gather_textual_report,
     mock_find_highest_report_level,
     mock_run_convert2rhel,
+    mock_inhibitor_check,
     mock_install_convert2rhel,
     mock_setup_convert2rhel,
     mock_gather_json_report,
@@ -31,6 +33,7 @@ def test_main_success(
 
     assert mock_setup_convert2rhel.call_count == 1
     assert mock_install_convert2rhel.call_count == 1
+    assert mock_inhibitor_check.call_count == 1
     assert mock_run_convert2rhel.call_count == 1
     assert mock_gather_json_report.call_count == 1
     assert mock_find_highest_report_level.call_count == 1
@@ -45,6 +48,7 @@ def test_main_success(
 @patch("scripts.preconversion_assessment_script.gather_json_report", side_effect=[{"actions": []}])
 @patch("scripts.preconversion_assessment_script.setup_convert2rhel", side_effect=Mock())
 @patch("scripts.preconversion_assessment_script.install_convert2rhel", return_value=(True, 1))
+@patch("scripts.preconversion_assessment_script.check_convert2rhel_inhibitors_before_run", return_value=("", 0))
 @patch("scripts.preconversion_assessment_script.run_convert2rhel", side_effect=ProcessError("test", "Process error"))
 @patch("scripts.preconversion_assessment_script.find_highest_report_level", side_effect=Mock(return_value=["SUCCESS"]))
 @patch("scripts.preconversion_assessment_script.gather_textual_report", side_effect=Mock(return_value=""))
@@ -57,6 +61,7 @@ def test_main_process_error(
     mock_gather_textual_report,
     mock_find_highest_report_level,
     mock_run_convert2rhel,
+    mock_inhibitor_check,
     mock_install_convert2rhel,
     mock_setup_convert2rhel,
     mock_gather_json_report,
@@ -66,6 +71,7 @@ def test_main_process_error(
 
     assert mock_setup_convert2rhel.call_count == 1
     assert mock_install_convert2rhel.call_count == 1
+    assert mock_inhibitor_check.call_count == 1
     assert mock_run_convert2rhel.call_count == 1
     assert mock_gather_json_report.call_count == 0
     assert mock_find_highest_report_level.call_count == 0
@@ -79,6 +85,7 @@ def test_main_process_error(
 @patch("__builtin__.open", mock_open(read_data="not json serializable"))
 @patch("scripts.preconversion_assessment_script.setup_convert2rhel", side_effect=Mock())
 @patch("scripts.preconversion_assessment_script.install_convert2rhel", return_value=(True, 1))
+@patch("scripts.preconversion_assessment_script.check_convert2rhel_inhibitors_before_run", return_value=("", 0))
 @patch("scripts.preconversion_assessment_script.run_convert2rhel", side_effect=Mock())
 @patch("scripts.preconversion_assessment_script.find_highest_report_level", side_effect=Mock(return_value=["SUCCESS"]))
 @patch("scripts.preconversion_assessment_script.gather_textual_report", side_effect=Mock(return_value=""))
@@ -91,6 +98,7 @@ def test_main_general_exception(
     mock_gather_textual_report,
     mock_find_highest_report_level,
     mock_run_convert2rhel,
+    mock_inhibitor_check,
     mock_install_convert2rhel,
     mock_setup_convert2rhel,
 ):
@@ -98,7 +106,77 @@ def test_main_general_exception(
 
     assert mock_setup_convert2rhel.call_count == 1
     assert mock_install_convert2rhel.call_count == 1
+    assert mock_inhibitor_check.call_count == 1
     assert mock_run_convert2rhel.call_count == 1
+    assert mock_find_highest_report_level.call_count == 0
+    assert mock_gather_textual_report.call_count == 0
+    assert mock_generate_report_message.call_count == 0
+    assert mock_cleanup.call_count == 1
+
+
+# fmt: off
+@patch("__builtin__.open", mock_open(read_data="not json serializable"))
+@patch("scripts.preconversion_assessment_script.setup_convert2rhel", side_effect=Mock())
+@patch("scripts.preconversion_assessment_script.install_convert2rhel", side_effect=Mock())
+@patch("os.path.exists", return_value=False)
+@patch("scripts.preconversion_assessment_script._check_ini_file_modified", return_value=True)
+@patch("scripts.preconversion_assessment_script.run_convert2rhel", side_effect=Mock())
+@patch("scripts.preconversion_assessment_script.find_highest_report_level", side_effect=Mock(return_value=["SUCCESS"]))
+@patch("scripts.preconversion_assessment_script.gather_textual_report", side_effect=Mock(return_value=""))
+@patch("scripts.preconversion_assessment_script.generate_report_message", side_effect=Mock(return_value=("", False)))
+@patch("scripts.preconversion_assessment_script.cleanup", side_effect=Mock())
+# fmt: on
+def test_main_inhibited_ini_modified(
+    mock_cleanup,
+    mock_generate_report_message,
+    mock_gather_textual_report,
+    mock_find_highest_report_level,
+    mock_run_convert2rhel,
+    mock_custom_ini,
+    mock_ini_modified,
+    mock_install_convert2rhel,
+    mock_setup_convert2rhel,
+):
+    main()
+
+    assert mock_setup_convert2rhel.call_count == 1
+    assert mock_custom_ini.call_count == 1
+    assert mock_ini_modified.call_count == 1
+    assert mock_install_convert2rhel.call_count == 0
+    assert mock_run_convert2rhel.call_count == 0
+    assert mock_find_highest_report_level.call_count == 0
+    assert mock_gather_textual_report.call_count == 0
+    assert mock_generate_report_message.call_count == 0
+    assert mock_cleanup.call_count == 1
+
+
+# fmt: off
+@patch("__builtin__.open", mock_open(read_data="not json serializable"))
+@patch("scripts.preconversion_assessment_script.setup_convert2rhel", side_effect=Mock())
+@patch("scripts.preconversion_assessment_script.install_convert2rhel", side_effect=Mock())
+@patch("os.path.exists", return_value=True)
+@patch("scripts.preconversion_assessment_script.run_convert2rhel", side_effect=Mock())
+@patch("scripts.preconversion_assessment_script.find_highest_report_level", side_effect=Mock(return_value=["SUCCESS"]))
+@patch("scripts.preconversion_assessment_script.gather_textual_report", side_effect=Mock(return_value=""))
+@patch("scripts.preconversion_assessment_script.generate_report_message", side_effect=Mock(return_value=("", False)))
+@patch("scripts.preconversion_assessment_script.cleanup", side_effect=Mock())
+# fmt: on
+def test_main_inhibited_custom_ini(
+    mock_cleanup,
+    mock_generate_report_message,
+    mock_gather_textual_report,
+    mock_find_highest_report_level,
+    mock_run_convert2rhel,
+    mock_inhibitor_check,
+    mock_install_convert2rhel,
+    mock_setup_convert2rhel,
+):
+    main()
+
+    assert mock_setup_convert2rhel.call_count == 1
+    assert mock_inhibitor_check.call_count == 1
+    assert mock_install_convert2rhel.call_count == 0
+    assert mock_run_convert2rhel.call_count == 0
     assert mock_find_highest_report_level.call_count == 0
     assert mock_gather_textual_report.call_count == 0
     assert mock_generate_report_message.call_count == 0


### PR DESCRIPTION
[HMS-3072](https://issues.redhat.com/browse/HMS-3072)

- [x] Before the conversion & pre-conversion scripts calls to convert2rhel, look whether the /etc/convert2rhel.ini has been edited or whether ~/.convert2rhel.ini exists (see ini logic in https://github.com/oamg/convert2rhel/blob/v1.5.0/config/convert2rhel.ini)