### PR TITLE
Cleanup c2r pkg correctly

### DIFF
--- a/scripts/conversion_script.py
+++ b/scripts/conversion_script.py
@@ -234,7 +234,7 @@ def install_convert2rhel():
     """
     print("Installing & updating Convert2RHEL package.")
 
-    c2r_pkg_name = 'convert2rhel'
+    c2r_pkg_name = "convert2rhel"
     c2r_installed = _check_if_package_installed(c2r_pkg_name)
 
     if not c2r_installed:
@@ -249,9 +249,7 @@ def install_convert2rhel():
             )
         return True
 
-    output, returncode = run_subprocess(
-        ["/usr/bin/yum", "update", c2r_pkg_name, "-y"]
-    )
+    output, returncode = run_subprocess(["/usr/bin/yum", "update", c2r_pkg_name, "-y"])
     if returncode:
         raise ProcessError(
             message="Failed to update convert2rhel RPM.",

--- a/scripts/conversion_script.py
+++ b/scripts/conversion_script.py
@@ -222,6 +222,8 @@ def run_subprocess(cmd, print_cmd=True, env=None):
     return output, process.returncode
 
 
+# TODO: When c2r statistics on insights are not reliant on rpm being installed
+# Copy from preconversion script the logic in this commit (pkgs_to_cleanup param)
 def install_convert2rhel():
     """Install the convert2rhel tool to the system."""
     print("Installing & updating Convert2RHEL package.")

--- a/scripts/conversion_script.py
+++ b/scripts/conversion_script.py
@@ -227,9 +227,9 @@ def run_subprocess(cmd, print_cmd=True, env=None):
 def _get_last_yum_transaction_id(pkg_name):
     output, return_code = run_subprocess(["/usr/bin/yum", "history", "list", pkg_name])
     if return_code:
-        # NOTE: There is only print because list will exi with 1 when no such transaction exist
+        # NOTE: There is only print because list will exit with 1 when no such transaction exist
         print(
-            "Listing yum transaction history for '%s' failed with exist status '%s' and output '%s'"
+            "Listing yum transaction history for '%s' failed with exit status '%s' and output '%s'"
             % (pkg_name, return_code, output),
             "\nThis may cause clean up function to not remove '%s' after Task run."
             % pkg_name,
@@ -249,7 +249,7 @@ def _check_if_package_installed(pkg_name):
 def install_convert2rhel():
     """
     Install the convert2rhel tool to the system.
-    Returns True if the yum transaction should be undone during cleanup.
+    Returns True and transaction ID if the c2r pkg was installed, otherwise False, None.
     """
     print("Installing & updating Convert2RHEL package.")
 
@@ -329,7 +329,7 @@ def cleanup(required_files):
         )
         if returncode:
             print(
-                "Undo of yum transaction with ID %s failed with exist status '%s' and output '%s'"
+                "Undo of yum transaction with ID %s failed with exit status '%s' and output '%s'"
                 % (transaction_id, returncode, output)
             )
 

--- a/scripts/conversion_script.py
+++ b/scripts/conversion_script.py
@@ -464,8 +464,8 @@ def main():
         host="https://www.redhat.com/security/data/fd431d51.txt",
     )
     c2r_repo = RequiredFile(
-            path="/etc/yum.repos.d/convert2rhel.repo",
-            host="https://ftp.redhat.com/redhat/convert2rhel/7/convert2rhel.repo",
+        path="/etc/yum.repos.d/convert2rhel.repo",
+        host="https://ftp.redhat.com/redhat/convert2rhel/7/convert2rhel.repo",
     )
     required_files = [
         gpg_key_file,

--- a/scripts/conversion_script.py
+++ b/scripts/conversion_script.py
@@ -231,11 +231,12 @@ def _get_last_yum_transaction_id(pkg_name):
         print(
             "Listing yum transaction history for '%s' failed with exist status '%s' and output '%s'"
             % (pkg_name, return_code, output),
-            "\nThis may cause clean up function to not remove '%s' after Task run." % pkg_name
+            "\nThis may cause clean up function to not remove '%s' after Task run."
+            % pkg_name,
         )
         return None
 
-    pattern = re.compile(r'^(\s+)?(\d+)', re.MULTILINE)
+    pattern = re.compile(r"^(\s+)?(\d+)", re.MULTILINE)
     matches = pattern.findall(output)
     return matches[-1][1] if matches else None
 
@@ -331,6 +332,7 @@ def cleanup(required_files):
                 "Undo of yum transaction with ID %s failed with exist status '%s' and output '%s'"
                 % (transaction_id, returncode, output)
             )
+
 
 def _create_or_restore_backup_file(required_file):
     """

--- a/scripts/conversion_script.py
+++ b/scripts/conversion_script.py
@@ -285,7 +285,7 @@ def run_convert2rhel():
         )
 
 
-def cleanup(required_files, undo_last_yum_transaction=False):
+def cleanup(required_files, undo_last_yum_transaction=True):
     """
     Cleanup the downloaded files downloaded in previous steps in this script.
 
@@ -440,7 +440,7 @@ def update_insights_inventory():
 
 def main():
     """Main entrypoint for the script."""
-    c2r_installed_undo = False # set to True if c2r pkg is installed
+    c2r_installed_undo = True
     output = OutputCollector()
     gpg_key_file = RequiredFile(
         path="/etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release",

--- a/scripts/conversion_script.py
+++ b/scripts/conversion_script.py
@@ -263,7 +263,7 @@ def install_convert2rhel():
         if returncode:
             raise ProcessError(
                 message="Failed to install convert2rhel RPM.",
-                report="Installing convert2rhel with yum exited with code '%s' and output: %s."
+                report="Installing convert2rhel with yum exited with code '%s' and output:\n%s"
                 % (returncode, output.rstrip("\n")),
             )
         transaction_id = _get_last_yum_transaction_id(c2r_pkg_name)
@@ -273,7 +273,7 @@ def install_convert2rhel():
     if returncode:
         raise ProcessError(
             message="Failed to update convert2rhel RPM.",
-            report="Updating convert2rhel with yum exited with code '%s' and output: %s."
+            report="Updating convert2rhel with yum exited with code '%s' and output:\n%s"
             % (returncode, output.rstrip("\n")),
         )
     # NOTE: If we would like to undo update we could use _get_last_yum_transaction_id(c2r_pkg_name)
@@ -299,7 +299,7 @@ def run_convert2rhel():
                 "An error occurred during the conversion execution. For details, refer to "
                 "the convert2rhel log file on the host at /var/log/convert2rhel/convert2rhel.log"
             ),
-            report="convert2rhel execution exited with code '%s'and output: %s."
+            report="convert2rhel execution exited with code '%s'and output:\n%s"
             % (returncode, output.rstrip("\n")),
         )
 
@@ -329,7 +329,7 @@ def cleanup(required_files):
         )
         if returncode:
             print(
-                "Undo of yum transaction with ID %s failed with exit status '%s' and output '%s'"
+                "Undo of yum transaction with ID %s failed with exit status '%s' and output:\n%s"
                 % (transaction_id, returncode, output)
             )
 
@@ -450,7 +450,7 @@ def update_insights_inventory():
     if returncode:
         raise ProcessError(
             message="Failed to update Insights Inventory by registering the system again.",
-            report="insights-client execution exited with code '%s' and output: %s."
+            report="insights-client execution exited with code '%s' and output:\n%s"
             % (returncode, output.rstrip("\n")),
         )
 
@@ -459,7 +459,6 @@ def update_insights_inventory():
 
 def main():
     """Main entrypoint for the script."""
-    c2r_installed_undo = True
     output = OutputCollector()
     gpg_key_file = RequiredFile(
         path="/etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release",

--- a/scripts/preconversion_assessment_script.py
+++ b/scripts/preconversion_assessment_script.py
@@ -226,11 +226,12 @@ def _get_last_yum_transaction_id(pkg_name):
         print(
             "Listing yum transaction history for '%s' failed with exist status '%s' and output '%s'"
             % (pkg_name, return_code, output),
-            "\nThis may cause clean up function to not remove '%s' after Task run." % pkg_name
+            "\nThis may cause clean up function to not remove '%s' after Task run."
+            % pkg_name,
         )
         return None
 
-    pattern = re.compile(r'^(\s+)?(\d+)', re.MULTILINE)
+    pattern = re.compile(r"^(\s+)?(\d+)", re.MULTILINE)
     matches = pattern.findall(output)
     return matches[-1][1] if matches else None
 

--- a/scripts/preconversion_assessment_script.py
+++ b/scripts/preconversion_assessment_script.py
@@ -281,7 +281,7 @@ def run_convert2rhel():
         )
 
 
-def cleanup(required_files, undo_last_yum_transaction=False):
+def cleanup(required_files, undo_last_yum_transaction=True):
     """
     Cleanup the downloaded files downloaded in previous steps in this script.
 
@@ -418,7 +418,7 @@ def transform_raw_data(raw_data):
 
 def main():
     """Main entrypoint for the script."""
-    c2r_installed_undo = False # set to True if c2r pkg is installed
+    c2r_installed_undo = True
     output = OutputCollector()
     required_files = [
         RequiredFile(

--- a/scripts/preconversion_assessment_script.py
+++ b/scripts/preconversion_assessment_script.py
@@ -258,7 +258,7 @@ def install_convert2rhel():
         if returncode:
             raise ProcessError(
                 message="Failed to install convert2rhel RPM.",
-                report="Installing convert2rhel with yum exited with code '%s' and output: %s."
+                report="Installing convert2rhel with yum exited with code '%s' and output:\n%s"
                 % (returncode, output.rstrip("\n")),
             )
         transaction_id = _get_last_yum_transaction_id(c2r_pkg_name)
@@ -268,7 +268,7 @@ def install_convert2rhel():
     if returncode:
         raise ProcessError(
             message="Failed to update convert2rhel RPM.",
-            report="Updating convert2rhel with yum exited with code '%s' and output: %s."
+            report="Updating convert2rhel with yum exited with code '%s' and output:\n%s"
             % (returncode, output.rstrip("\n")),
         )
     # NOTE: If we would like to undo update we could use _get_last_yum_transaction_id(c2r_pkg_name)
@@ -296,7 +296,7 @@ def run_convert2rhel():
                 "An error occurred during the pre-conversion analysis. "
                 "For details, refer to the convert2rhel log file on the host at /var/log/convert2rhel/convert2rhel.log"
             ),
-            report="convert2rhel execution exited with code '%s' and output: %s."
+            report="convert2rhel execution exited with code '%s' and output:\n%s"
             % (returncode, output.rstrip("\n")),
         )
 
@@ -324,7 +324,7 @@ def cleanup(required_files):
         )
         if returncode:
             print(
-                "Undo of yum transaction with ID %s failed with exit status '%s' and output '%s'"
+                "Undo of yum transaction with ID %s failed with exit status '%s' and output:\n%s"
                 % (transaction_id, returncode, output)
             )
 
@@ -439,7 +439,6 @@ def transform_raw_data(raw_data):
 
 def main():
     """Main entrypoint for the script."""
-    c2r_installed_undo = True
     output = OutputCollector()
     required_files = [
         RequiredFile(

--- a/scripts/preconversion_assessment_script.py
+++ b/scripts/preconversion_assessment_script.py
@@ -222,9 +222,9 @@ def run_subprocess(cmd, print_cmd=True, env=None):
 def _get_last_yum_transaction_id(pkg_name):
     output, return_code = run_subprocess(["/usr/bin/yum", "history", "list", pkg_name])
     if return_code:
-        # NOTE: There is only print because list will exi with 1 when no such transaction exist
+        # NOTE: There is only print because list will exit with 1 when no such transaction exist
         print(
-            "Listing yum transaction history for '%s' failed with exist status '%s' and output '%s'"
+            "Listing yum transaction history for '%s' failed with exit status '%s' and output '%s'"
             % (pkg_name, return_code, output),
             "\nThis may cause clean up function to not remove '%s' after Task run."
             % pkg_name,
@@ -244,7 +244,7 @@ def _check_if_package_installed(pkg_name):
 def install_convert2rhel():
     """
     Install the convert2rhel tool to the system.
-    Returns True if the yum transaction should be undone during cleanup.
+    Returns True and transaction ID if the c2r pkg was installed, otherwise False, None.
     """
     print("Installing & updating Convert2RHEL package.")
 
@@ -324,7 +324,7 @@ def cleanup(required_files):
         )
         if returncode:
             print(
-                "Undo of yum transaction with ID %s failed with exist status '%s' and output '%s'"
+                "Undo of yum transaction with ID %s failed with exit status '%s' and output '%s'"
                 % (transaction_id, returncode, output)
             )
 

--- a/scripts/preconversion_assessment_script.py
+++ b/scripts/preconversion_assessment_script.py
@@ -229,7 +229,7 @@ def install_convert2rhel():
     """
     print("Installing & updating Convert2RHEL package.")
 
-    c2r_pkg_name = 'convert2rhel'
+    c2r_pkg_name = "convert2rhel"
     c2r_installed = _check_if_package_installed(c2r_pkg_name)
 
     if not c2r_installed:
@@ -244,9 +244,7 @@ def install_convert2rhel():
             )
         return True
 
-    output, returncode = run_subprocess(
-        ["/usr/bin/yum", "update", c2r_pkg_name, "-y"]
-    )
+    output, returncode = run_subprocess(["/usr/bin/yum", "update", c2r_pkg_name, "-y"])
     if returncode:
         raise ProcessError(
             message="Failed to update convert2rhel RPM.",
@@ -254,6 +252,7 @@ def install_convert2rhel():
             % (returncode, output.rstrip("\n")),
         )
     return False
+
 
 def run_convert2rhel():
     """
@@ -307,6 +306,7 @@ def cleanup(required_files, undo_last_yum_transaction=True):
                 "Undo of last yum transaction failed with exist status '%s' and output '%s'"
                 % (returncode, output)
             )
+
 
 def _create_or_restore_backup_file(required_file):
     """

--- a/scripts/preconversion_assessment_script.py
+++ b/scripts/preconversion_assessment_script.py
@@ -1,5 +1,6 @@
 import json
 import os
+import re
 import subprocess
 import copy
 
@@ -20,6 +21,7 @@ STATUS_CODE_NAME = {number: name for name, number in STATUS_CODE.items()}
 C2R_REPORT_FILE = "/var/log/convert2rhel/convert2rhel-pre-conversion.json"
 # Path to the convert2rhel report textual file.
 C2R_REPORT_TXT_FILE = "/var/log/convert2rhel/convert2rhel-pre-conversion.txt"
+YUM_TRANSACTIONS_TO_UNDO = set()
 
 
 class RequiredFile(object):
@@ -217,6 +219,22 @@ def run_subprocess(cmd, print_cmd=True, env=None):
     return output, process.returncode
 
 
+def _get_last_yum_transaction_id(pkg_name):
+    output, return_code = run_subprocess(["/usr/bin/yum", "history", "list", pkg_name])
+    if return_code:
+        # NOTE: There is only print because list will exi with 1 when no such transaction exist
+        print(
+            "Listing yum transaction history for '%s' failed with exist status '%s' and output '%s'"
+            % (pkg_name, return_code, output),
+            "\nThis may cause clean up function to not remove '%s' after Task run." % pkg_name
+        )
+        return None
+
+    pattern = re.compile(r'^(\s+)?(\d+)', re.MULTILINE)
+    matches = pattern.findall(output)
+    return matches[-1][1] if matches else None
+
+
 def _check_if_package_installed(pkg_name):
     _, return_code = run_subprocess(["/usr/bin/rpm", "-q", pkg_name])
     return return_code == 0
@@ -242,7 +260,8 @@ def install_convert2rhel():
                 report="Installing convert2rhel with yum exited with code '%s' and output: %s."
                 % (returncode, output.rstrip("\n")),
             )
-        return True
+        transaction_id = _get_last_yum_transaction_id(c2r_pkg_name)
+        return True, transaction_id
 
     output, returncode = run_subprocess(["/usr/bin/yum", "update", c2r_pkg_name, "-y"])
     if returncode:
@@ -251,7 +270,8 @@ def install_convert2rhel():
             report="Updating convert2rhel with yum exited with code '%s' and output: %s."
             % (returncode, output.rstrip("\n")),
         )
-    return False
+    # NOTE: If we would like to undo update we could use _get_last_yum_transaction_id(c2r_pkg_name)
+    return False, None
 
 
 def run_convert2rhel():
@@ -280,7 +300,7 @@ def run_convert2rhel():
         )
 
 
-def cleanup(required_files, undo_last_yum_transaction=True):
+def cleanup(required_files):
     """
     Cleanup the downloaded files downloaded in previous steps in this script.
 
@@ -297,14 +317,14 @@ def cleanup(required_files, undo_last_yum_transaction=True):
             os.remove(required_file.path)
         _create_or_restore_backup_file(required_file)
 
-    if undo_last_yum_transaction:
+    for transaction_id in YUM_TRANSACTIONS_TO_UNDO:
         output, returncode = run_subprocess(
-            ["/usr/bin/yum", "history", "undo", "last"],
+            ["/usr/bin/yum", "history", "undo", transaction_id],
         )
         if returncode:
             print(
-                "Undo of last yum transaction failed with exist status '%s' and output '%s'"
-                % (returncode, output)
+                "Undo of yum transaction with ID %s failed with exist status '%s' and output '%s'"
+                % (transaction_id, returncode, output)
             )
 
 
@@ -434,7 +454,9 @@ def main():
     try:
         # Setup Convert2RHEL to be executed.
         setup_convert2rhel(required_files)
-        c2r_installed_undo = install_convert2rhel()
+        installed, transaction_id = install_convert2rhel()
+        if installed:
+            YUM_TRANSACTIONS_TO_UNDO.add(transaction_id)
         run_convert2rhel()
 
         # Gather JSON & Textual report
@@ -472,7 +494,7 @@ def main():
         )
     finally:
         print("Cleaning up modifications to the system.")
-        cleanup(required_files, undo_last_yum_transaction=c2r_installed_undo)
+        cleanup(required_files)
 
         print("### JSON START ###")
         print(json.dumps(output.to_dict(), indent=4))

--- a/tests/conversion_script/test_check_pkg_installed.py
+++ b/tests/conversion_script/test_check_pkg_installed.py
@@ -1,0 +1,13 @@
+from mock import patch
+
+from scripts.conversion_script import _check_if_package_installed
+
+
+@patch("scripts.conversion_script.run_subprocess")
+def test_check_if_package_installed(mock_run_subprocess):
+    pkg_name = "example-package"
+    mock_run_subprocess.return_value = ("", 0)
+    result = _check_if_package_installed(pkg_name)
+    expected_command = ["/usr/bin/rpm", "-q", pkg_name]
+    mock_run_subprocess.assert_called_once_with(expected_command)
+    assert result

--- a/tests/conversion_script/test_cleanup.py
+++ b/tests/conversion_script/test_cleanup.py
@@ -2,6 +2,7 @@ from mock import Mock, patch
 
 from scripts.conversion_script import cleanup, RequiredFile
 
+
 @patch("scripts.conversion_script.YUM_TRANSACTIONS_TO_UNDO", new=set())
 @patch("scripts.conversion_script.run_subprocess", return_value=("", 0))
 @patch("os.path.exists", side_effect=Mock())

--- a/tests/conversion_script/test_cleanup.py
+++ b/tests/conversion_script/test_cleanup.py
@@ -7,7 +7,9 @@ from scripts.conversion_script import cleanup, RequiredFile
 @patch("os.path.exists", side_effect=Mock())
 @patch("os.remove", side_effect=Mock())
 @patch("scripts.conversion_script._create_or_restore_backup_file")
-def test_cleanup_with_file_to_remove(mock_restore, mock_remove, mock_exists, mock_yum_undo):
+def test_cleanup_with_file_to_remove(
+    mock_restore, mock_remove, mock_exists, mock_yum_undo
+):
     """Only downloaded files are removed."""
 
     present_file = RequiredFile("/already/present")
@@ -26,7 +28,9 @@ def test_cleanup_with_file_to_remove(mock_restore, mock_remove, mock_exists, moc
 @patch("os.path.exists", side_effect=Mock())
 @patch("os.remove", side_effect=Mock())
 @patch("scripts.conversion_script._create_or_restore_backup_file")
-def test_cleanup_with_file_to_keep(mock_restore, mock_remove, mock_exists, mock_yum_undo):
+def test_cleanup_with_file_to_keep(
+    mock_restore, mock_remove, mock_exists, mock_yum_undo
+):
     """Only downloaded files are removed."""
 
     keep_downloaded_file = RequiredFile("/download/keep", keep=True)
@@ -39,7 +43,6 @@ def test_cleanup_with_file_to_keep(mock_restore, mock_remove, mock_exists, mock_
     assert mock_remove.call_count == 0
     assert mock_restore.call_count == 0
     assert mock_yum_undo.call_count == 0
-
 
 
 @patch("scripts.conversion_script.run_subprocess", return_value=("", 1))

--- a/tests/conversion_script/test_cleanup.py
+++ b/tests/conversion_script/test_cleanup.py
@@ -2,7 +2,7 @@ from mock import Mock, patch
 
 from scripts.conversion_script import cleanup, RequiredFile
 
-
+@patch("scripts.conversion_script.YUM_TRANSACTIONS_TO_UNDO", new=set())
 @patch("scripts.conversion_script.run_subprocess", return_value=("", 0))
 @patch("os.path.exists", side_effect=Mock())
 @patch("os.remove", side_effect=Mock())
@@ -21,9 +21,10 @@ def test_cleanup_with_file_to_remove(
     assert mock_exists.call_count == 1
     assert mock_remove.call_count == 1
     assert mock_restore.call_count == 1
-    assert mock_yum_undo.call_count == 1
+    assert mock_yum_undo.call_count == 0
 
 
+@patch("scripts.conversion_script.YUM_TRANSACTIONS_TO_UNDO", new=set())
 @patch("scripts.conversion_script.run_subprocess", return_value=("", 1))
 @patch("os.path.exists", side_effect=Mock())
 @patch("os.remove", side_effect=Mock())
@@ -36,7 +37,7 @@ def test_cleanup_with_file_to_keep(
     keep_downloaded_file = RequiredFile("/download/keep", keep=True)
     required_files = [keep_downloaded_file]
 
-    cleanup(required_files, undo_last_yum_transaction=False)
+    cleanup(required_files)
 
     # For removal of file, then two checks in backup function
     assert mock_exists.call_count == 0
@@ -45,6 +46,7 @@ def test_cleanup_with_file_to_keep(
     assert mock_yum_undo.call_count == 0
 
 
+@patch("scripts.conversion_script.YUM_TRANSACTIONS_TO_UNDO", new=set([1]))
 @patch("scripts.conversion_script.run_subprocess", return_value=("", 1))
 @patch("os.path.exists", side_effect=Mock())
 @patch("os.remove", side_effect=Mock())
@@ -55,7 +57,7 @@ def test_cleanup_with_undo_yum(mock_restore, mock_remove, mock_exists, mock_yum_
     present_file = RequiredFile("/already/present")
     required_files = [present_file]
 
-    cleanup(required_files, undo_last_yum_transaction=True)
+    cleanup(required_files)
 
     # For removal of file, then two checks in backup function
     assert mock_exists.call_count == 1

--- a/tests/conversion_script/test_cleanup.py
+++ b/tests/conversion_script/test_cleanup.py
@@ -3,10 +3,11 @@ from mock import Mock, patch
 from scripts.conversion_script import cleanup, RequiredFile
 
 
+@patch("scripts.conversion_script.run_subprocess", return_value=("", 0))
 @patch("os.path.exists", side_effect=Mock())
 @patch("os.remove", side_effect=Mock())
 @patch("scripts.conversion_script._create_or_restore_backup_file")
-def test_cleanup_with_file_to_remove(mock_restore, mock_remove, mock_exists):
+def test_cleanup_with_file_to_remove(mock_restore, mock_remove, mock_exists, mock_yum_undo):
     """Only downloaded files are removed."""
 
     present_file = RequiredFile("/already/present")
@@ -18,20 +19,43 @@ def test_cleanup_with_file_to_remove(mock_restore, mock_remove, mock_exists):
     assert mock_exists.call_count == 1
     assert mock_remove.call_count == 1
     assert mock_restore.call_count == 1
+    assert mock_yum_undo.call_count == 1
 
 
+@patch("scripts.conversion_script.run_subprocess", return_value=("", 1))
 @patch("os.path.exists", side_effect=Mock())
 @patch("os.remove", side_effect=Mock())
 @patch("scripts.conversion_script._create_or_restore_backup_file")
-def test_cleanup_with_file_to_keep(mock_restore, mock_remove, mock_exists):
+def test_cleanup_with_file_to_keep(mock_restore, mock_remove, mock_exists, mock_yum_undo):
     """Only downloaded files are removed."""
 
     keep_downloaded_file = RequiredFile("/download/keep", keep=True)
     required_files = [keep_downloaded_file]
 
-    cleanup(required_files)
+    cleanup(required_files, undo_last_yum_transaction=False)
 
     # For removal of file, then two checks in backup function
     assert mock_exists.call_count == 0
     assert mock_remove.call_count == 0
     assert mock_restore.call_count == 0
+    assert mock_yum_undo.call_count == 0
+
+
+
+@patch("scripts.conversion_script.run_subprocess", return_value=("", 1))
+@patch("os.path.exists", side_effect=Mock())
+@patch("os.remove", side_effect=Mock())
+@patch("scripts.conversion_script._create_or_restore_backup_file")
+def test_cleanup_with_undo_yum(mock_restore, mock_remove, mock_exists, mock_yum_undo):
+    """Only downloaded files are removed."""
+
+    present_file = RequiredFile("/already/present")
+    required_files = [present_file]
+
+    cleanup(required_files, undo_last_yum_transaction=True)
+
+    # For removal of file, then two checks in backup function
+    assert mock_exists.call_count == 1
+    assert mock_remove.call_count == 1
+    assert mock_restore.call_count == 1
+    assert mock_yum_undo.call_count == 1

--- a/tests/conversion_script/test_generate_report_message.py
+++ b/tests/conversion_script/test_generate_report_message.py
@@ -3,40 +3,34 @@ from scripts.conversion_script import RequiredFile, generate_report_message
 
 
 @pytest.mark.parametrize(
-    ("highest_status", "expected_message", "has_alert", "file_should_be_kept"),
+    ("highest_status", "expected_message", "has_alert"),
     [
         (
             "SUCCESS",
             "No problems found. The system was converted successfully.",
             False,
-            True,
         ),
         (
             "INFO",
             "No problems found. The system was converted successfully.",
             False,
-            True,
         ),
         (
             "WARNING",
             "No problems found. The system was converted successfully.",
             False,
-            True,
         ),
         (
             "ERROR",
             "The conversion cannot proceed. You must resolve existing issues to perform the conversion.",
             True,
-            False,
         ),
     ],
 )
 def test_generate_report_message(
-    highest_status, expected_message, has_alert, file_should_be_kept
+    highest_status, expected_message, has_alert,
 ):
-    file = RequiredFile("/foo/bar")
-    assert generate_report_message(highest_status, file) == (
+    assert generate_report_message(highest_status) == (
         expected_message,
         has_alert,
     )
-    assert file.keep is file_should_be_kept

--- a/tests/conversion_script/test_generate_report_message.py
+++ b/tests/conversion_script/test_generate_report_message.py
@@ -28,7 +28,9 @@ from scripts.conversion_script import RequiredFile, generate_report_message
     ],
 )
 def test_generate_report_message(
-    highest_status, expected_message, has_alert,
+    highest_status,
+    expected_message,
+    has_alert,
 ):
     assert generate_report_message(highest_status) == (
         expected_message,

--- a/tests/conversion_script/test_get_last_yum_transaction.py
+++ b/tests/conversion_script/test_get_last_yum_transaction.py
@@ -1,0 +1,26 @@
+import pytest
+from mock import patch
+
+from scripts.conversion_script import _get_last_yum_transaction_id
+
+
+@pytest.mark.parametrize("mock_return, expected_result", [
+    (("8 | install -y convert2rhel | 2023-11-23 16:53 | Install | 6", 0), "8"),
+    (("    9 | install -y convert2rhel | 2023-11-23 16:53 | Update | 6", 0), "9"),
+    (("| install -y convert2rhel | 2023-11-23 16:53 | Erase | 6", 0), None),
+    (("12 | install -y package4 | 2023-11-24 10:30 | Install | 2\n"
+      "8 | install -y convert2rhel | 2023-11-23 16:53 | Update | 6", 0), "8"),
+    (("", 1), None),
+])
+def test_get_last_yum_transaction_id(mock_return, expected_result):
+    pkg_name = "convert2rhel"
+
+    with patch(
+        "scripts.conversion_script.run_subprocess",
+        return_value=mock_return
+    ) as mock_run_subprocess:
+        result = _get_last_yum_transaction_id(pkg_name)
+
+    mock_run_subprocess.assert_called_once()
+
+    assert result == expected_result

--- a/tests/conversion_script/test_get_last_yum_transaction.py
+++ b/tests/conversion_script/test_get_last_yum_transaction.py
@@ -4,20 +4,28 @@ from mock import patch
 from scripts.conversion_script import _get_last_yum_transaction_id
 
 
-@pytest.mark.parametrize("mock_return, expected_result", [
-    (("8 | install -y convert2rhel | 2023-11-23 16:53 | Install | 6", 0), "8"),
-    (("    9 | install -y convert2rhel | 2023-11-23 16:53 | Update | 6", 0), "9"),
-    (("| install -y convert2rhel | 2023-11-23 16:53 | Erase | 6", 0), None),
-    (("12 | install -y package4 | 2023-11-24 10:30 | Install | 2\n"
-      "8 | install -y convert2rhel | 2023-11-23 16:53 | Update | 6", 0), "8"),
-    (("", 1), None),
-])
+@pytest.mark.parametrize(
+    "mock_return, expected_result",
+    [
+        (("8 | install -y convert2rhel | 2023-11-23 16:53 | Install | 6", 0), "8"),
+        (("    9 | install -y convert2rhel | 2023-11-23 16:53 | Update | 6", 0), "9"),
+        (("| install -y convert2rhel | 2023-11-23 16:53 | Erase | 6", 0), None),
+        (
+            (
+                "12 | install -y package4 | 2023-11-24 10:30 | Install | 2\n"
+                "8 | install -y convert2rhel | 2023-11-23 16:53 | Update | 6",
+                0,
+            ),
+            "8",
+        ),
+        (("", 1), None),
+    ],
+)
 def test_get_last_yum_transaction_id(mock_return, expected_result):
     pkg_name = "convert2rhel"
 
     with patch(
-        "scripts.conversion_script.run_subprocess",
-        return_value=mock_return
+        "scripts.conversion_script.run_subprocess", return_value=mock_return
     ) as mock_run_subprocess:
         result = _get_last_yum_transaction_id(pkg_name)
 

--- a/tests/conversion_script/test_install.py
+++ b/tests/conversion_script/test_install.py
@@ -50,7 +50,7 @@ def test_install_convert2rhel(
 def test_install_convert2rhel_raise_exception(mock_run_subprocess, mock_pkg_check):
     with pytest.raises(
         ProcessError,
-        match="Installing convert2rhel with yum exited with code '1' and output: failed.",
+        match="Installing convert2rhel with yum exited with code '1' and output:\nfailed",
     ):
         install_convert2rhel()
 
@@ -65,7 +65,7 @@ def test_install_convert2rhel_raise_exception(mock_run_subprocess, mock_pkg_chec
 def test_update_convert2rhel_raise_exception(mock_run_subprocess, mock_pkg_check):
     with pytest.raises(
         ProcessError,
-        match="Updating convert2rhel with yum exited with code '1' and output: failed.",
+        match="Updating convert2rhel with yum exited with code '1' and output:\nfailed",
     ):
         install_convert2rhel()
 

--- a/tests/conversion_script/test_install.py
+++ b/tests/conversion_script/test_install.py
@@ -26,8 +26,7 @@ def test_install_convert2rhel(
             return_value=pkg_installed_mock,
         ) as mock_run_pkg_check:
             with patch(
-                "scripts.conversion_script._get_last_yum_transaction_id",
-                return_value=1
+                "scripts.conversion_script._get_last_yum_transaction_id", return_value=1
             ) as mock_transaction_get:
                 should_undo, _ = install_convert2rhel()
 

--- a/tests/conversion_script/test_install.py
+++ b/tests/conversion_script/test_install.py
@@ -10,11 +10,13 @@ from scripts.conversion_script import (
 @pytest.mark.parametrize(
     ("subprocess_mock", "pkg_installed_mock", "should_undo_transaction"),
     (
-        ((b"output", 0), False , True),
-        ((b"output", 0), True , False),
+        ((b"output", 0), False, True),
+        ((b"output", 0), True, False),
     ),
 )
-def test_install_convert2rhel(subprocess_mock, pkg_installed_mock, should_undo_transaction):
+def test_install_convert2rhel(
+    subprocess_mock, pkg_installed_mock, should_undo_transaction
+):
     with patch(
         "scripts.conversion_script.run_subprocess",
         return_value=subprocess_mock,
@@ -34,9 +36,7 @@ def test_install_convert2rhel(subprocess_mock, pkg_installed_mock, should_undo_t
             ["/usr/bin/yum", "update", "convert2rhel", "-y"],
         ]
     else:
-        expected_calls = [
-            ["/usr/bin/yum", "install", "convert2rhel", "-y"]
-        ]
+        expected_calls = [["/usr/bin/yum", "install", "convert2rhel", "-y"]]
 
     assert mock_run_subprocess.call_args_list == [call(args) for args in expected_calls]
 

--- a/tests/conversion_script/test_install.py
+++ b/tests/conversion_script/test_install.py
@@ -7,52 +7,67 @@ from scripts.conversion_script import (
 )
 
 
-@pytest.mark.parametrize("subprocess_mock", [(b"output", 0), (b"output", 0)])
-def test_install_convert2rhel(subprocess_mock):
+@pytest.mark.parametrize(
+    ("subprocess_mock", "pkg_installed_mock", "should_undo_transaction"),
+    (
+        ((b"output", 0), False , True),
+        ((b"output", 0), True , False),
+    ),
+)
+def test_install_convert2rhel(subprocess_mock, pkg_installed_mock, should_undo_transaction):
     with patch(
         "scripts.conversion_script.run_subprocess",
         return_value=subprocess_mock,
     ) as mock_run_subprocess:
-        install_convert2rhel()
+        with patch(
+            "scripts.conversion_script._check_if_package_installed",
+            return_value=pkg_installed_mock,
+        ) as mock_run_pkg_check:
+            return_status = install_convert2rhel()
 
-    expected_calls = [
-        ["/usr/bin/yum", "install", "convert2rhel", "-y"],
-        ["/usr/bin/yum", "update", "convert2rhel", "-y"],
-    ]
+    assert return_status is should_undo_transaction
+    mock_run_pkg_check.assert_called_once()
+    mock_run_subprocess.assert_called_once()
+
+    if pkg_installed_mock:
+        expected_calls = [
+            ["/usr/bin/yum", "update", "convert2rhel", "-y"],
+        ]
+    else:
+        expected_calls = [
+            ["/usr/bin/yum", "install", "convert2rhel", "-y"]
+        ]
 
     assert mock_run_subprocess.call_args_list == [call(args) for args in expected_calls]
 
 
-def test_install_convert2rhel_raise_exception():
-    with patch(
-        "scripts.conversion_script.run_subprocess",
-        return_value=(b"failed", 1),
-    ) as mock_run_subprocess:
-        with pytest.raises(
-            ProcessError,
-            match="Installing convert2rhel with yum exited with code '1' and output: failed.",
-        ):
-            install_convert2rhel()
+@patch("scripts.conversion_script._check_if_package_installed", return_value=False)
+@patch("scripts.conversion_script.run_subprocess", return_value=(b"failed", 1))
+def test_install_convert2rhel_raise_exception(mock_run_subprocess, mock_pkg_check):
+    with pytest.raises(
+        ProcessError,
+        match="Installing convert2rhel with yum exited with code '1' and output: failed.",
+    ):
+        install_convert2rhel()
 
     expected_calls = [["/usr/bin/yum", "install", "convert2rhel", "-y"]]
 
+    mock_pkg_check.assert_called_once()
     assert mock_run_subprocess.call_args_list == [call(args) for args in expected_calls]
 
 
-def test_update_convert2rhel_raise_exception():
-    with patch(
-        "scripts.conversion_script.run_subprocess",
-        side_effect=[(b"output", 0), (b"failed", 1)],
-    ) as mock_run_subprocess:
-        with pytest.raises(
-            ProcessError,
-            match="Updating convert2rhel with yum exited with code '1' and output: failed.",
-        ):
-            install_convert2rhel()
+@patch("scripts.conversion_script._check_if_package_installed", return_value=True)
+@patch("scripts.conversion_script.run_subprocess", return_value=(b"failed", 1))
+def test_update_convert2rhel_raise_exception(mock_run_subprocess, mock_pkg_check):
+    with pytest.raises(
+        ProcessError,
+        match="Updating convert2rhel with yum exited with code '1' and output: failed.",
+    ):
+        install_convert2rhel()
 
     expected_calls = [
-        ["/usr/bin/yum", "install", "convert2rhel", "-y"],
         ["/usr/bin/yum", "update", "convert2rhel", "-y"],
     ]
 
+    mock_pkg_check.assert_called_once()
     assert mock_run_subprocess.call_args_list == [call(args) for args in expected_calls]

--- a/tests/conversion_script/test_install.py
+++ b/tests/conversion_script/test_install.py
@@ -25,11 +25,16 @@ def test_install_convert2rhel(
             "scripts.conversion_script._check_if_package_installed",
             return_value=pkg_installed_mock,
         ) as mock_run_pkg_check:
-            return_status = install_convert2rhel()
+            with patch(
+                "scripts.conversion_script._get_last_yum_transaction_id",
+                return_value=1
+            ) as mock_transaction_get:
+                should_undo, _ = install_convert2rhel()
 
-    assert return_status is should_undo_transaction
+    assert should_undo is should_undo_transaction
     mock_run_pkg_check.assert_called_once()
     mock_run_subprocess.assert_called_once()
+    assert mock_transaction_get.call_count == (0 if pkg_installed_mock else 1)
 
     if pkg_installed_mock:
         expected_calls = [

--- a/tests/conversion_script/test_main.py
+++ b/tests/conversion_script/test_main.py
@@ -109,4 +109,3 @@ def test_main_general_exception(
     assert mock_gather_textual_report.call_count == 0
     assert mock_generate_report_message.call_count == 0
     mock_cleanup.assert_called_once_with(ANY, undo_last_yum_transaction=True)
-

--- a/tests/conversion_script/test_main.py
+++ b/tests/conversion_script/test_main.py
@@ -46,8 +46,9 @@ def test_main_success_c2r_installed(
     assert mock_generate_report_message.call_count == 1
     # NOTE: we should expect below one call once we don't require rpm because of insights conversion statistics
     assert mock_cleanup_pkg_call.call_count == 0
-    assert mock_cleanup_file_exists_call.call_count == 2
-    assert mock_cleanup_file_restore_call.call_count == 2
+    # NOTE: successful conversion keeps gpg and repo on system (the backup is also kept)
+    assert mock_cleanup_file_exists_call.call_count == 0
+    assert mock_cleanup_file_restore_call.call_count == 0
     assert mock_transform_raw_data.call_count == 1
 
 

--- a/tests/conversion_script/test_main.py
+++ b/tests/conversion_script/test_main.py
@@ -96,7 +96,6 @@ def test_main_inhibited_c2r_installed(
     assert mock_transform_raw_data.call_count == 1
 
 
-
 # fmt: off
 @patch("__builtin__.open", new_callable=mock_open())
 @patch("scripts.conversion_script.gather_json_report", side_effect=[{"actions": []}])

--- a/tests/conversion_script/test_main.py
+++ b/tests/conversion_script/test_main.py
@@ -109,3 +109,4 @@ def test_main_general_exception(
     assert mock_gather_textual_report.call_count == 0
     assert mock_generate_report_message.call_count == 0
     mock_cleanup.assert_called_once_with(ANY, undo_last_yum_transaction=True)
+

--- a/tests/conversion_script/test_main.py
+++ b/tests/conversion_script/test_main.py
@@ -1,6 +1,6 @@
 # pylint: disable=too-many-arguments
 
-from mock import patch, mock_open, Mock
+from mock import patch, mock_open, Mock, ANY
 
 from scripts.conversion_script import main, ProcessError
 
@@ -9,11 +9,11 @@ from scripts.conversion_script import main, ProcessError
 @patch("scripts.conversion_script.gather_json_report", side_effect=[{"actions": []}])
 @patch("scripts.conversion_script.update_insights_inventory", side_effect=Mock())
 @patch("scripts.conversion_script.setup_convert2rhel", side_effect=Mock())
-@patch("scripts.conversion_script.install_convert2rhel", side_effect=Mock())
+@patch("scripts.conversion_script.install_convert2rhel", return_value=True)
 @patch("scripts.conversion_script.run_convert2rhel", side_effect=Mock())
 @patch("scripts.conversion_script.find_highest_report_level", side_effect=Mock(return_value=["SUCCESS"]))
 @patch("scripts.conversion_script.gather_textual_report", side_effect=Mock(return_value=""))
-@patch("scripts.conversion_script.generate_report_message", side_effect=Mock(return_value=("", False)))
+@patch("scripts.conversion_script.generate_report_message", side_effect=Mock(return_value=("successfully", False)))
 @patch("scripts.conversion_script.transform_raw_data", side_effect=Mock(return_value=""))
 @patch("scripts.conversion_script.cleanup", side_effect=Mock())
 # fmt: on
@@ -40,6 +40,9 @@ def test_main_success(
     assert mock_gather_textual_report.call_count == 1
     assert mock_generate_report_message.call_count == 1
     assert mock_cleanup.call_count == 1
+    # NOTE: When c2r statistics on insights are not reliant on rpm being installed
+    # we should expect True here
+    mock_cleanup.assert_called_once_with(ANY, undo_last_yum_transaction=False)
     assert mock_transform_raw_data.call_count == 1
 
 
@@ -47,11 +50,11 @@ def test_main_success(
 @patch("__builtin__.open", new_callable=mock_open())
 @patch("scripts.conversion_script.gather_json_report", side_effect=[{"actions": []}])
 @patch("scripts.conversion_script.setup_convert2rhel", side_effect=Mock())
-@patch("scripts.conversion_script.install_convert2rhel", side_effect=Mock())
+@patch("scripts.conversion_script.install_convert2rhel", return_value=True)
 @patch("scripts.conversion_script.run_convert2rhel", side_effect=ProcessError("test", "Process error"))
 @patch("scripts.conversion_script.find_highest_report_level", side_effect=Mock(return_value=["SUCCESS"]))
 @patch("scripts.conversion_script.gather_textual_report", side_effect=Mock(return_value=""))
-@patch("scripts.conversion_script.generate_report_message", side_effect=Mock(return_value=("", False)))
+@patch("scripts.conversion_script.generate_report_message", side_effect=Mock(return_value=("failed", False)))
 @patch("scripts.conversion_script.cleanup", side_effect=Mock())
 # fmt: on
 def test_main_process_error(
@@ -74,17 +77,17 @@ def test_main_process_error(
     assert mock_find_highest_report_level.call_count == 0
     assert mock_gather_textual_report.call_count == 0
     assert mock_generate_report_message.call_count == 0
-    assert mock_cleanup.call_count == 1
+    mock_cleanup.assert_called_once_with(ANY, undo_last_yum_transaction=True)
     assert mock_open_func.call_count == 0
 
 
 # fmt: off
 @patch("__builtin__.open", mock_open(read_data="not json serializable"))
 @patch("scripts.conversion_script.setup_convert2rhel", side_effect=Mock())
-@patch("scripts.conversion_script.install_convert2rhel", side_effect=Mock())
+@patch("scripts.conversion_script.install_convert2rhel", return_value=True)
 @patch("scripts.conversion_script.run_convert2rhel", side_effect=Mock())
 @patch("scripts.conversion_script.find_highest_report_level", side_effect=Mock(return_value=["SUCCESS"]))
-@patch("scripts.conversion_script.gather_textual_report", side_effect=Mock(return_value=""))
+@patch("scripts.conversion_script.gather_textual_report", side_effect=Mock(return_value="failed"))
 @patch("scripts.conversion_script.generate_report_message", side_effect=Mock(return_value=("", False)))
 @patch("scripts.conversion_script.cleanup", side_effect=Mock())
 # fmt: on
@@ -105,4 +108,5 @@ def test_main_general_exception(
     assert mock_find_highest_report_level.call_count == 0
     assert mock_gather_textual_report.call_count == 0
     assert mock_generate_report_message.call_count == 0
-    assert mock_cleanup.call_count == 1
+    mock_cleanup.assert_called_once_with(ANY, undo_last_yum_transaction=True)
+

--- a/tests/conversion_script/test_main.py
+++ b/tests/conversion_script/test_main.py
@@ -1,6 +1,6 @@
 # pylint: disable=too-many-arguments
 
-from mock import patch, mock_open, Mock, ANY
+from mock import patch, mock_open, Mock
 
 from scripts.conversion_script import main, ProcessError
 
@@ -9,16 +9,21 @@ from scripts.conversion_script import main, ProcessError
 @patch("scripts.conversion_script.gather_json_report", side_effect=[{"actions": []}])
 @patch("scripts.conversion_script.update_insights_inventory", side_effect=Mock())
 @patch("scripts.conversion_script.setup_convert2rhel", side_effect=Mock())
-@patch("scripts.conversion_script.install_convert2rhel", return_value=True)
+@patch("scripts.conversion_script.install_convert2rhel", return_value=(True, 1))
 @patch("scripts.conversion_script.run_convert2rhel", side_effect=Mock())
 @patch("scripts.conversion_script.find_highest_report_level", side_effect=Mock(return_value=["SUCCESS"]))
 @patch("scripts.conversion_script.gather_textual_report", side_effect=Mock(return_value=""))
 @patch("scripts.conversion_script.generate_report_message", side_effect=Mock(return_value=("successfully", False)))
 @patch("scripts.conversion_script.transform_raw_data", side_effect=Mock(return_value=""))
-@patch("scripts.conversion_script.cleanup", side_effect=Mock())
+# These patches are calls made in cleanup
+@patch("os.path.exists", return_value=False)
+@patch("scripts.conversion_script._create_or_restore_backup_file", side_effect=Mock())
+@patch("scripts.conversion_script.run_subprocess", return_value=("", 1))
 # fmt: on
-def test_main_success(
-    mock_cleanup,
+def test_main_success_c2r_installed(
+    mock_cleanup_pkg_call,
+    mock_cleanup_file_restore_call,
+    mock_cleanup_file_exists_call,
     mock_transform_raw_data,
     mock_generate_report_message,
     mock_gather_textual_report,
@@ -39,18 +44,64 @@ def test_main_success(
     assert mock_find_highest_report_level.call_count == 1
     assert mock_gather_textual_report.call_count == 1
     assert mock_generate_report_message.call_count == 1
-    assert mock_cleanup.call_count == 1
-    # NOTE: When c2r statistics on insights are not reliant on rpm being installed
-    # we should expect True here
-    mock_cleanup.assert_called_once_with(ANY, undo_last_yum_transaction=False)
+    # NOTE: we should expect below one call once we don't require rpm because of insights conversion statistics
+    assert mock_cleanup_pkg_call.call_count == 0
+    assert mock_cleanup_file_exists_call.call_count == 2
+    assert mock_cleanup_file_restore_call.call_count == 2
     assert mock_transform_raw_data.call_count == 1
+
+
+# fmt: off
+@patch("scripts.conversion_script.gather_json_report", side_effect=[{"actions": []}])
+@patch("scripts.conversion_script.update_insights_inventory", side_effect=Mock())
+@patch("scripts.conversion_script.setup_convert2rhel", side_effect=Mock())
+@patch("scripts.conversion_script.install_convert2rhel", return_value=(True, 1))
+@patch("scripts.conversion_script.run_convert2rhel", side_effect=Mock())
+@patch("scripts.conversion_script.find_highest_report_level", side_effect=Mock(return_value=["SUCCESS"]))
+@patch("scripts.conversion_script.gather_textual_report", side_effect=Mock(return_value=""))
+@patch("scripts.conversion_script.generate_report_message", side_effect=Mock(return_value=("inhibited", False)))
+@patch("scripts.conversion_script.transform_raw_data", side_effect=Mock(return_value=""))
+# These patches are calls made in cleanup
+@patch("os.path.exists", return_value=False)
+@patch("scripts.conversion_script._create_or_restore_backup_file", side_effect=Mock())
+@patch("scripts.conversion_script.run_subprocess", return_value=("", 1))
+# fmt: on
+def test_main_inhibited_c2r_installed(
+    mock_cleanup_pkg_call,
+    mock_cleanup_file_restore_call,
+    mock_cleanup_file_exists_call,
+    mock_transform_raw_data,
+    mock_generate_report_message,
+    mock_gather_textual_report,
+    mock_find_highest_report_level,
+    mock_run_convert2rhel,
+    mock_install_convert2rhel,
+    mock_setup_convert2rhel,
+    mock_update_insights_inventory,
+    mock_gather_json_report,
+):
+    main()
+
+    assert mock_setup_convert2rhel.call_count == 1
+    assert mock_install_convert2rhel.call_count == 1
+    assert mock_run_convert2rhel.call_count == 1
+    assert mock_update_insights_inventory.call_count == 1
+    assert mock_gather_json_report.call_count == 1
+    assert mock_find_highest_report_level.call_count == 1
+    assert mock_gather_textual_report.call_count == 1
+    assert mock_generate_report_message.call_count == 1
+    assert mock_cleanup_pkg_call.call_count == 1
+    assert mock_cleanup_file_exists_call.call_count == 2
+    assert mock_cleanup_file_restore_call.call_count == 2
+    assert mock_transform_raw_data.call_count == 1
+
 
 
 # fmt: off
 @patch("__builtin__.open", new_callable=mock_open())
 @patch("scripts.conversion_script.gather_json_report", side_effect=[{"actions": []}])
 @patch("scripts.conversion_script.setup_convert2rhel", side_effect=Mock())
-@patch("scripts.conversion_script.install_convert2rhel", return_value=True)
+@patch("scripts.conversion_script.install_convert2rhel", return_value=(False, 1))
 @patch("scripts.conversion_script.run_convert2rhel", side_effect=ProcessError("test", "Process error"))
 @patch("scripts.conversion_script.find_highest_report_level", side_effect=Mock(return_value=["SUCCESS"]))
 @patch("scripts.conversion_script.gather_textual_report", side_effect=Mock(return_value=""))
@@ -77,14 +128,14 @@ def test_main_process_error(
     assert mock_find_highest_report_level.call_count == 0
     assert mock_gather_textual_report.call_count == 0
     assert mock_generate_report_message.call_count == 0
-    mock_cleanup.assert_called_once_with(ANY, undo_last_yum_transaction=True)
+    assert mock_cleanup.call_count == 1
     assert mock_open_func.call_count == 0
 
 
 # fmt: off
 @patch("__builtin__.open", mock_open(read_data="not json serializable"))
 @patch("scripts.conversion_script.setup_convert2rhel", side_effect=Mock())
-@patch("scripts.conversion_script.install_convert2rhel", return_value=True)
+@patch("scripts.conversion_script.install_convert2rhel", return_value=(False, 1))
 @patch("scripts.conversion_script.run_convert2rhel", side_effect=Mock())
 @patch("scripts.conversion_script.find_highest_report_level", side_effect=Mock(return_value=["SUCCESS"]))
 @patch("scripts.conversion_script.gather_textual_report", side_effect=Mock(return_value="failed"))
@@ -108,5 +159,4 @@ def test_main_general_exception(
     assert mock_find_highest_report_level.call_count == 0
     assert mock_gather_textual_report.call_count == 0
     assert mock_generate_report_message.call_count == 0
-    mock_cleanup.assert_called_once_with(ANY, undo_last_yum_transaction=True)
-
+    assert mock_cleanup.call_count == 1

--- a/tests/preconversion_assessment/test_check_pkg_installed.py
+++ b/tests/preconversion_assessment/test_check_pkg_installed.py
@@ -1,0 +1,13 @@
+from mock import patch
+
+from scripts.preconversion_assessment_script import _check_if_package_installed
+
+
+@patch("scripts.preconversion_assessment_script.run_subprocess")
+def test_check_if_package_installed(mock_run_subprocess):
+    pkg_name = "example-package"
+    mock_run_subprocess.return_value = ("", 0)
+    result = _check_if_package_installed(pkg_name)
+    expected_command = ["/usr/bin/rpm", "-q", pkg_name]
+    mock_run_subprocess.assert_called_once_with(expected_command)
+    assert result

--- a/tests/preconversion_assessment/test_cleanup.py
+++ b/tests/preconversion_assessment/test_cleanup.py
@@ -3,18 +3,40 @@ from mock import Mock, patch
 from scripts.preconversion_assessment_script import cleanup, RequiredFile
 
 
+@patch("scripts.preconversion_assessment_script.run_subprocess", return_value=("", 0))
 @patch("os.path.exists", side_effect=Mock())
 @patch("os.remove", side_effect=Mock())
 @patch("scripts.preconversion_assessment_script._create_or_restore_backup_file")
-def test_cleanup_with_file_to_remove(mock_restore, mock_remove, mock_exists):
+def test_cleanup_with_file_to_remove(mock_restore, mock_remove, mock_exists, mock_yum_undo):
     """Only downloaded files are removed."""
 
     present_file = RequiredFile("/already/present")
     required_files = [present_file]
 
-    cleanup(required_files)
+    cleanup(required_files, undo_last_yum_transaction=False)
 
     # For removal of file, then two checks in backup function
     assert mock_exists.call_count == 1
     assert mock_remove.call_count == 1
     assert mock_restore.call_count == 1
+    assert mock_yum_undo.call_count == 0
+
+
+@patch("scripts.preconversion_assessment_script.run_subprocess", return_value=("", 1))
+@patch("os.path.exists", side_effect=Mock())
+@patch("os.remove", side_effect=Mock())
+@patch("scripts.preconversion_assessment_script._create_or_restore_backup_file")
+def test_cleanup_with_undo_yum(mock_restore, mock_remove, mock_exists, mock_yum_undo):
+    """Only downloaded files are removed."""
+
+    present_file = RequiredFile("/already/present")
+    required_files = [present_file]
+
+    cleanup(required_files, undo_last_yum_transaction=True)
+
+    # For removal of file, then two checks in backup function
+    assert mock_exists.call_count == 1
+    assert mock_remove.call_count == 1
+    assert mock_restore.call_count == 1
+    assert mock_yum_undo.call_count == 1
+

--- a/tests/preconversion_assessment/test_cleanup.py
+++ b/tests/preconversion_assessment/test_cleanup.py
@@ -7,7 +7,9 @@ from scripts.preconversion_assessment_script import cleanup, RequiredFile
 @patch("os.path.exists", side_effect=Mock())
 @patch("os.remove", side_effect=Mock())
 @patch("scripts.preconversion_assessment_script._create_or_restore_backup_file")
-def test_cleanup_with_file_to_remove(mock_restore, mock_remove, mock_exists, mock_yum_undo):
+def test_cleanup_with_file_to_remove(
+    mock_restore, mock_remove, mock_exists, mock_yum_undo
+):
     """Only downloaded files are removed."""
 
     present_file = RequiredFile("/already/present")
@@ -39,4 +41,3 @@ def test_cleanup_with_undo_yum(mock_restore, mock_remove, mock_exists, mock_yum_
     assert mock_remove.call_count == 1
     assert mock_restore.call_count == 1
     assert mock_yum_undo.call_count == 1
-

--- a/tests/preconversion_assessment/test_cleanup.py
+++ b/tests/preconversion_assessment/test_cleanup.py
@@ -3,6 +3,7 @@ from mock import Mock, patch
 from scripts.preconversion_assessment_script import cleanup, RequiredFile
 
 
+@patch("scripts.preconversion_assessment_script.YUM_TRANSACTIONS_TO_UNDO", new=set())
 @patch("scripts.preconversion_assessment_script.run_subprocess", return_value=("", 0))
 @patch("os.path.exists", side_effect=Mock())
 @patch("os.remove", side_effect=Mock())
@@ -15,7 +16,7 @@ def test_cleanup_with_file_to_remove(
     present_file = RequiredFile("/already/present")
     required_files = [present_file]
 
-    cleanup(required_files, undo_last_yum_transaction=False)
+    cleanup(required_files)
 
     # For removal of file, then two checks in backup function
     assert mock_exists.call_count == 1
@@ -24,6 +25,7 @@ def test_cleanup_with_file_to_remove(
     assert mock_yum_undo.call_count == 0
 
 
+@patch("scripts.preconversion_assessment_script.YUM_TRANSACTIONS_TO_UNDO", new=set([1]))
 @patch("scripts.preconversion_assessment_script.run_subprocess", return_value=("", 1))
 @patch("os.path.exists", side_effect=Mock())
 @patch("os.remove", side_effect=Mock())
@@ -33,8 +35,7 @@ def test_cleanup_with_undo_yum(mock_restore, mock_remove, mock_exists, mock_yum_
 
     present_file = RequiredFile("/already/present")
     required_files = [present_file]
-
-    cleanup(required_files, undo_last_yum_transaction=True)
+    cleanup(required_files)
 
     # For removal of file, then two checks in backup function
     assert mock_exists.call_count == 1

--- a/tests/preconversion_assessment/test_get_last_yum_transaction.py
+++ b/tests/preconversion_assessment/test_get_last_yum_transaction.py
@@ -4,20 +4,29 @@ from mock import patch
 from scripts.preconversion_assessment_script import _get_last_yum_transaction_id
 
 
-@pytest.mark.parametrize("mock_return, expected_result", [
-    (("8 | install -y convert2rhel | 2023-11-23 16:53 | Install | 6", 0), "8"),
-    (("    9 | install -y convert2rhel | 2023-11-23 16:53 | Update | 6", 0), "9"),
-    (("| install -y convert2rhel | 2023-11-23 16:53 | Erase | 6", 0), None),
-    (("12 | install -y package4 | 2023-11-24 10:30 | Install | 2\n"
-      "8 | install -y convert2rhel | 2023-11-23 16:53 | Update | 6", 0), "8"),
-    (("", 1), None),
-])
+@pytest.mark.parametrize(
+    "mock_return, expected_result",
+    [
+        (("8 | install -y convert2rhel | 2023-11-23 16:53 | Install | 6", 0), "8"),
+        (("    9 | install -y convert2rhel | 2023-11-23 16:53 | Update | 6", 0), "9"),
+        (("| install -y convert2rhel | 2023-11-23 16:53 | Erase | 6", 0), None),
+        (
+            (
+                "12 | install -y package4 | 2023-11-24 10:30 | Install | 2\n"
+                "8 | install -y convert2rhel | 2023-11-23 16:53 | Update | 6",
+                0,
+            ),
+            "8",
+        ),
+        (("", 1), None),
+    ],
+)
 def test_get_last_yum_transaction_id(mock_return, expected_result):
     pkg_name = "convert2rhel"
 
     with patch(
         "scripts.preconversion_assessment_script.run_subprocess",
-        return_value=mock_return
+        return_value=mock_return,
     ) as mock_run_subprocess:
         result = _get_last_yum_transaction_id(pkg_name)
 

--- a/tests/preconversion_assessment/test_get_last_yum_transaction.py
+++ b/tests/preconversion_assessment/test_get_last_yum_transaction.py
@@ -1,0 +1,26 @@
+import pytest
+from mock import patch
+
+from scripts.preconversion_assessment_script import _get_last_yum_transaction_id
+
+
+@pytest.mark.parametrize("mock_return, expected_result", [
+    (("8 | install -y convert2rhel | 2023-11-23 16:53 | Install | 6", 0), "8"),
+    (("    9 | install -y convert2rhel | 2023-11-23 16:53 | Update | 6", 0), "9"),
+    (("| install -y convert2rhel | 2023-11-23 16:53 | Erase | 6", 0), None),
+    (("12 | install -y package4 | 2023-11-24 10:30 | Install | 2\n"
+      "8 | install -y convert2rhel | 2023-11-23 16:53 | Update | 6", 0), "8"),
+    (("", 1), None),
+])
+def test_get_last_yum_transaction_id(mock_return, expected_result):
+    pkg_name = "convert2rhel"
+
+    with patch(
+        "scripts.preconversion_assessment_script.run_subprocess",
+        return_value=mock_return
+    ) as mock_run_subprocess:
+        result = _get_last_yum_transaction_id(pkg_name)
+
+    mock_run_subprocess.assert_called_once()
+
+    assert result == expected_result

--- a/tests/preconversion_assessment/test_install.py
+++ b/tests/preconversion_assessment/test_install.py
@@ -10,11 +10,13 @@ from scripts.preconversion_assessment_script import (
 @pytest.mark.parametrize(
     ("subprocess_mock", "pkg_installed_mock", "should_undo_transaction"),
     (
-        ((b"output", 0), False , True),
-        ((b"output", 0), True , False),  # just update with no removed packages
+        ((b"output", 0), False, True),
+        ((b"output", 0), True, False),  # just update with no removed packages
     ),
 )
-def test_install_convert2rhel(subprocess_mock, pkg_installed_mock, should_undo_transaction):
+def test_install_convert2rhel(
+    subprocess_mock, pkg_installed_mock, should_undo_transaction
+):
     with patch(
         "scripts.preconversion_assessment_script.run_subprocess",
         return_value=subprocess_mock,
@@ -34,15 +36,19 @@ def test_install_convert2rhel(subprocess_mock, pkg_installed_mock, should_undo_t
             ["/usr/bin/yum", "update", "convert2rhel", "-y"],
         ]
     else:
-        expected_calls = [
-            ["/usr/bin/yum", "install", "convert2rhel", "-y"]
-        ]
+        expected_calls = [["/usr/bin/yum", "install", "convert2rhel", "-y"]]
 
     assert mock_run_subprocess.call_args_list == [call(args) for args in expected_calls]
 
 
-@patch("scripts.preconversion_assessment_script._check_if_package_installed", return_value=False)
-@patch("scripts.preconversion_assessment_script.run_subprocess", return_value=(b"failed", 1))
+@patch(
+    "scripts.preconversion_assessment_script._check_if_package_installed",
+    return_value=False,
+)
+@patch(
+    "scripts.preconversion_assessment_script.run_subprocess",
+    return_value=(b"failed", 1),
+)
 def test_install_convert2rhel_raise_exception(mock_run_subprocess, mock_pkg_check):
     with pytest.raises(
         ProcessError,
@@ -56,8 +62,14 @@ def test_install_convert2rhel_raise_exception(mock_run_subprocess, mock_pkg_chec
     assert mock_run_subprocess.call_args_list == [call(args) for args in expected_calls]
 
 
-@patch("scripts.preconversion_assessment_script._check_if_package_installed", return_value=True)
-@patch("scripts.preconversion_assessment_script.run_subprocess", return_value=(b"failed", 1))
+@patch(
+    "scripts.preconversion_assessment_script._check_if_package_installed",
+    return_value=True,
+)
+@patch(
+    "scripts.preconversion_assessment_script.run_subprocess",
+    return_value=(b"failed", 1),
+)
 def test_update_convert2rhel_raise_exception(mock_run_subprocess, mock_pkg_check):
     with pytest.raises(
         ProcessError,

--- a/tests/preconversion_assessment/test_install.py
+++ b/tests/preconversion_assessment/test_install.py
@@ -27,7 +27,7 @@ def test_install_convert2rhel(
         ) as mock_run_pkg_check:
             with patch(
                 "scripts.preconversion_assessment_script._get_last_yum_transaction_id",
-                return_value=1
+                return_value=1,
             ) as mock_transaction_get:
                 should_undo, _ = install_convert2rhel()
 

--- a/tests/preconversion_assessment/test_install.py
+++ b/tests/preconversion_assessment/test_install.py
@@ -57,7 +57,7 @@ def test_install_convert2rhel(
 def test_install_convert2rhel_raise_exception(mock_run_subprocess, mock_pkg_check):
     with pytest.raises(
         ProcessError,
-        match="Installing convert2rhel with yum exited with code '1' and output: failed.",
+        match="Installing convert2rhel with yum exited with code '1' and output:\nfailed",
     ):
         install_convert2rhel()
 
@@ -78,7 +78,7 @@ def test_install_convert2rhel_raise_exception(mock_run_subprocess, mock_pkg_chec
 def test_update_convert2rhel_raise_exception(mock_run_subprocess, mock_pkg_check):
     with pytest.raises(
         ProcessError,
-        match="Updating convert2rhel with yum exited with code '1' and output: failed.",
+        match="Updating convert2rhel with yum exited with code '1' and output:\nfailed",
     ):
         install_convert2rhel()
 

--- a/tests/preconversion_assessment/test_install.py
+++ b/tests/preconversion_assessment/test_install.py
@@ -7,52 +7,67 @@ from scripts.preconversion_assessment_script import (
 )
 
 
-@pytest.mark.parametrize("subprocess_mock", [(b"output", 0), (b"output", 0)])
-def test_install_convert2rhel(subprocess_mock):
+@pytest.mark.parametrize(
+    ("subprocess_mock", "pkg_installed_mock", "should_undo_transaction"),
+    (
+        ((b"output", 0), False , True),
+        ((b"output", 0), True , False),  # just update with no removed packages
+    ),
+)
+def test_install_convert2rhel(subprocess_mock, pkg_installed_mock, should_undo_transaction):
     with patch(
         "scripts.preconversion_assessment_script.run_subprocess",
         return_value=subprocess_mock,
     ) as mock_run_subprocess:
-        install_convert2rhel()
+        with patch(
+            "scripts.preconversion_assessment_script._check_if_package_installed",
+            return_value=pkg_installed_mock,
+        ) as mock_run_pkg_check:
+            return_status = install_convert2rhel()
 
-    expected_calls = [
-        ["/usr/bin/yum", "install", "convert2rhel", "-y"],
-        ["/usr/bin/yum", "update", "convert2rhel", "-y"],
-    ]
+    assert return_status is should_undo_transaction
+    mock_run_pkg_check.assert_called_once()
+    mock_run_subprocess.assert_called_once()
+
+    if pkg_installed_mock:
+        expected_calls = [
+            ["/usr/bin/yum", "update", "convert2rhel", "-y"],
+        ]
+    else:
+        expected_calls = [
+            ["/usr/bin/yum", "install", "convert2rhel", "-y"]
+        ]
 
     assert mock_run_subprocess.call_args_list == [call(args) for args in expected_calls]
 
 
-def test_install_convert2rhel_raise_exception():
-    with patch(
-        "scripts.preconversion_assessment_script.run_subprocess",
-        return_value=(b"failed", 1),
-    ) as mock_run_subprocess:
-        with pytest.raises(
-            ProcessError,
-            match="Installing convert2rhel with yum exited with code '1' and output: failed.",
-        ):
-            install_convert2rhel()
+@patch("scripts.preconversion_assessment_script._check_if_package_installed", return_value=False)
+@patch("scripts.preconversion_assessment_script.run_subprocess", return_value=(b"failed", 1))
+def test_install_convert2rhel_raise_exception(mock_run_subprocess, mock_pkg_check):
+    with pytest.raises(
+        ProcessError,
+        match="Installing convert2rhel with yum exited with code '1' and output: failed.",
+    ):
+        install_convert2rhel()
 
     expected_calls = [["/usr/bin/yum", "install", "convert2rhel", "-y"]]
 
+    mock_pkg_check.assert_called_once()
     assert mock_run_subprocess.call_args_list == [call(args) for args in expected_calls]
 
 
-def test_update_convert2rhel_raise_exception():
-    with patch(
-        "scripts.preconversion_assessment_script.run_subprocess",
-        side_effect=[(b"output", 0), (b"failed", 1)],
-    ) as mock_run_subprocess:
-        with pytest.raises(
-            ProcessError,
-            match="Updating convert2rhel with yum exited with code '1' and output: failed.",
-        ):
-            install_convert2rhel()
+@patch("scripts.preconversion_assessment_script._check_if_package_installed", return_value=True)
+@patch("scripts.preconversion_assessment_script.run_subprocess", return_value=(b"failed", 1))
+def test_update_convert2rhel_raise_exception(mock_run_subprocess, mock_pkg_check):
+    with pytest.raises(
+        ProcessError,
+        match="Updating convert2rhel with yum exited with code '1' and output: failed.",
+    ):
+        install_convert2rhel()
 
     expected_calls = [
-        ["/usr/bin/yum", "install", "convert2rhel", "-y"],
         ["/usr/bin/yum", "update", "convert2rhel", "-y"],
     ]
 
+    mock_pkg_check.assert_called_once()
     assert mock_run_subprocess.call_args_list == [call(args) for args in expected_calls]

--- a/tests/preconversion_assessment/test_main.py
+++ b/tests/preconversion_assessment/test_main.py
@@ -1,6 +1,6 @@
 # pylint: disable=too-many-arguments
 
-from mock import patch, mock_open, Mock
+from mock import patch, mock_open, Mock, ANY
 
 from scripts.preconversion_assessment_script import main, ProcessError
 
@@ -8,11 +8,11 @@ from scripts.preconversion_assessment_script import main, ProcessError
 # fmt: off
 @patch("scripts.preconversion_assessment_script.gather_json_report", side_effect=[{"actions": []}])
 @patch("scripts.preconversion_assessment_script.setup_convert2rhel", side_effect=Mock())
-@patch("scripts.preconversion_assessment_script.install_convert2rhel", side_effect=Mock())
+@patch("scripts.preconversion_assessment_script.install_convert2rhel", return_value=True)
 @patch("scripts.preconversion_assessment_script.run_convert2rhel", side_effect=Mock())
 @patch("scripts.preconversion_assessment_script.find_highest_report_level", side_effect=Mock(return_value=["SUCCESS"]))
 @patch("scripts.preconversion_assessment_script.gather_textual_report", side_effect=Mock(return_value=""))
-@patch("scripts.preconversion_assessment_script.generate_report_message", side_effect=Mock(return_value=("", False)))
+@patch("scripts.preconversion_assessment_script.generate_report_message", side_effect=Mock(return_value=("successfully", False)))
 @patch("scripts.preconversion_assessment_script.transform_raw_data", side_effect=Mock(return_value=""))
 @patch("scripts.preconversion_assessment_script.cleanup", side_effect=Mock())
 # fmt: on
@@ -36,7 +36,7 @@ def test_main_success(
     assert mock_find_highest_report_level.call_count == 1
     assert mock_gather_textual_report.call_count == 1
     assert mock_generate_report_message.call_count == 1
-    assert mock_cleanup.call_count == 1
+    mock_cleanup.assert_called_once_with(ANY, undo_last_yum_transaction=True)
     assert mock_transform_raw_data.call_count == 1
 
 
@@ -44,11 +44,11 @@ def test_main_success(
 @patch("__builtin__.open", new_callable=mock_open())
 @patch("scripts.preconversion_assessment_script.gather_json_report", side_effect=[{"actions": []}])
 @patch("scripts.preconversion_assessment_script.setup_convert2rhel", side_effect=Mock())
-@patch("scripts.preconversion_assessment_script.install_convert2rhel", side_effect=Mock())
+@patch("scripts.preconversion_assessment_script.install_convert2rhel", return_value=True)
 @patch("scripts.preconversion_assessment_script.run_convert2rhel", side_effect=ProcessError("test", "Process error"))
 @patch("scripts.preconversion_assessment_script.find_highest_report_level", side_effect=Mock(return_value=["SUCCESS"]))
 @patch("scripts.preconversion_assessment_script.gather_textual_report", side_effect=Mock(return_value=""))
-@patch("scripts.preconversion_assessment_script.generate_report_message", side_effect=Mock(return_value=("", False)))
+@patch("scripts.preconversion_assessment_script.generate_report_message", side_effect=Mock(return_value=("failed", False)))
 @patch("scripts.preconversion_assessment_script.cleanup", side_effect=Mock())
 # fmt: on
 def test_main_process_error(
@@ -71,18 +71,18 @@ def test_main_process_error(
     assert mock_find_highest_report_level.call_count == 0
     assert mock_gather_textual_report.call_count == 0
     assert mock_generate_report_message.call_count == 0
-    assert mock_cleanup.call_count == 1
+    mock_cleanup.assert_called_once_with(ANY, undo_last_yum_transaction=True)
     assert mock_open_func.call_count == 0
 
 
 # fmt: off
 @patch("__builtin__.open", mock_open(read_data="not json serializable"))
 @patch("scripts.preconversion_assessment_script.setup_convert2rhel", side_effect=Mock())
-@patch("scripts.preconversion_assessment_script.install_convert2rhel", side_effect=Mock())
+@patch("scripts.preconversion_assessment_script.install_convert2rhel", return_value=True)
 @patch("scripts.preconversion_assessment_script.run_convert2rhel", side_effect=Mock())
 @patch("scripts.preconversion_assessment_script.find_highest_report_level", side_effect=Mock(return_value=["SUCCESS"]))
 @patch("scripts.preconversion_assessment_script.gather_textual_report", side_effect=Mock(return_value=""))
-@patch("scripts.preconversion_assessment_script.generate_report_message", side_effect=Mock(return_value=("", False)))
+@patch("scripts.preconversion_assessment_script.generate_report_message", side_effect=Mock(return_value=("failed", False)))
 @patch("scripts.preconversion_assessment_script.cleanup", side_effect=Mock())
 # fmt: on
 def test_main_general_exception(
@@ -102,4 +102,4 @@ def test_main_general_exception(
     assert mock_find_highest_report_level.call_count == 0
     assert mock_gather_textual_report.call_count == 0
     assert mock_generate_report_message.call_count == 0
-    assert mock_cleanup.call_count == 1
+    mock_cleanup.assert_called_once_with(ANY, undo_last_yum_transaction=True)

--- a/tests/preconversion_assessment/test_main.py
+++ b/tests/preconversion_assessment/test_main.py
@@ -1,6 +1,6 @@
 # pylint: disable=too-many-arguments
 
-from mock import patch, mock_open, Mock, ANY
+from mock import patch, mock_open, Mock
 
 from scripts.preconversion_assessment_script import main, ProcessError
 
@@ -8,7 +8,7 @@ from scripts.preconversion_assessment_script import main, ProcessError
 # fmt: off
 @patch("scripts.preconversion_assessment_script.gather_json_report", side_effect=[{"actions": []}])
 @patch("scripts.preconversion_assessment_script.setup_convert2rhel", side_effect=Mock())
-@patch("scripts.preconversion_assessment_script.install_convert2rhel", return_value=True)
+@patch("scripts.preconversion_assessment_script.install_convert2rhel", return_value=(False, 1))
 @patch("scripts.preconversion_assessment_script.run_convert2rhel", side_effect=Mock())
 @patch("scripts.preconversion_assessment_script.find_highest_report_level", side_effect=Mock(return_value=["SUCCESS"]))
 @patch("scripts.preconversion_assessment_script.gather_textual_report", side_effect=Mock(return_value=""))
@@ -36,7 +36,7 @@ def test_main_success(
     assert mock_find_highest_report_level.call_count == 1
     assert mock_gather_textual_report.call_count == 1
     assert mock_generate_report_message.call_count == 1
-    mock_cleanup.assert_called_once_with(ANY, undo_last_yum_transaction=True)
+    assert mock_cleanup.call_count == 1
     assert mock_transform_raw_data.call_count == 1
 
 
@@ -44,7 +44,7 @@ def test_main_success(
 @patch("__builtin__.open", new_callable=mock_open())
 @patch("scripts.preconversion_assessment_script.gather_json_report", side_effect=[{"actions": []}])
 @patch("scripts.preconversion_assessment_script.setup_convert2rhel", side_effect=Mock())
-@patch("scripts.preconversion_assessment_script.install_convert2rhel", return_value=True)
+@patch("scripts.preconversion_assessment_script.install_convert2rhel", return_value=(True, 1))
 @patch("scripts.preconversion_assessment_script.run_convert2rhel", side_effect=ProcessError("test", "Process error"))
 @patch("scripts.preconversion_assessment_script.find_highest_report_level", side_effect=Mock(return_value=["SUCCESS"]))
 @patch("scripts.preconversion_assessment_script.gather_textual_report", side_effect=Mock(return_value=""))
@@ -71,14 +71,14 @@ def test_main_process_error(
     assert mock_find_highest_report_level.call_count == 0
     assert mock_gather_textual_report.call_count == 0
     assert mock_generate_report_message.call_count == 0
-    mock_cleanup.assert_called_once_with(ANY, undo_last_yum_transaction=True)
+    assert mock_cleanup.call_count == 1
     assert mock_open_func.call_count == 0
 
 
 # fmt: off
 @patch("__builtin__.open", mock_open(read_data="not json serializable"))
 @patch("scripts.preconversion_assessment_script.setup_convert2rhel", side_effect=Mock())
-@patch("scripts.preconversion_assessment_script.install_convert2rhel", return_value=True)
+@patch("scripts.preconversion_assessment_script.install_convert2rhel", return_value=(True, 1))
 @patch("scripts.preconversion_assessment_script.run_convert2rhel", side_effect=Mock())
 @patch("scripts.preconversion_assessment_script.find_highest_report_level", side_effect=Mock(return_value=["SUCCESS"]))
 @patch("scripts.preconversion_assessment_script.gather_textual_report", side_effect=Mock(return_value=""))
@@ -102,4 +102,5 @@ def test_main_general_exception(
     assert mock_find_highest_report_level.call_count == 0
     assert mock_gather_textual_report.call_count == 0
     assert mock_generate_report_message.call_count == 0
-    mock_cleanup.assert_called_once_with(ANY, undo_last_yum_transaction=True)
+    assert mock_cleanup.call_count == 1
+

--- a/tests/preconversion_assessment/test_main.py
+++ b/tests/preconversion_assessment/test_main.py
@@ -103,4 +103,3 @@ def test_main_general_exception(
     assert mock_gather_textual_report.call_count == 0
     assert mock_generate_report_message.call_count == 0
     assert mock_cleanup.call_count == 1
-


### PR DESCRIPTION
[HMS-3086](https://issues.redhat.com/browse/HMS-3086)

- [x] cleanup after pre-conversion
  - for both fails and successes - if convert2rhel existed on system before pkg is kept  on system (update of the pkg is not rolled back), else cleaned up
- [x] cleanup after conversion
  - for fails - if convert2rhel existed on system before pkg is kept on system (update of the pkg is not rolled back), else cleaned up 
  - for successes - pkg is always kept because of statistics with the note that this can be removed after we do not rely on that fact

