### PR TITLE
Parse failures in rollback log

### DIFF
--- a/scripts/conversion_script.py
+++ b/scripts/conversion_script.py
@@ -593,6 +593,7 @@ def update_insights_inventory():
 
 # pylint: disable=too-many-branches
 # pylint: disable=too-many-statements
+# pylint: disable=too-many-locals
 def main():
     """Main entrypoint for the script."""
     if os.path.exists(C2R_REPORT_FILE):

--- a/scripts/conversion_script.py
+++ b/scripts/conversion_script.py
@@ -35,7 +35,7 @@ YUM_TRANSACTIONS_TO_UNDO = set()
 # Define regex to look for specific errors in the rollback phase in
 # convert2rhel.
 DETECT_ERROR_IN_ROLLBACK_PATTERN = re.compile(
-    r".*(error|failed|fail|failure|denied|traceback|couldn't find a backup)",
+    r".*(error|fail|denied|traceback|couldn't find a backup)",
     flags=re.MULTILINE | re.I,
 )
 # Detect the last transaction id in yum.
@@ -654,12 +654,12 @@ def main():
         if not conversion_successful:
             raise ProcessError(
                 message=(
-                    "An error occurred during the pre-conversion execution. For details, refer to "
+                    "An error occurred during the pre-conversion analysis. For details, refer to "
                     "the convert2rhel log file on the host at /var/log/convert2rhel/convert2rhel.log"
                 ),
                 report=(
-                    "convert2rhel execution exited with code %s"
-                    "Output of failed command: %s" % (returncode, stdout.rstrip("\n"))
+                    "convert2rhel exited with code %s"
+                    "Output of the failed command: %s" % (returncode, stdout.rstrip("\n"))
                 ),
             )
 
@@ -679,7 +679,7 @@ def main():
                 % rollback_errors,
             )
 
-        print("Conversion script finish successfully!")
+        print("Conversion script finished successfully!")
     except ProcessError as exception:
         print(exception.report)
         output = OutputCollector(

--- a/scripts/conversion_script.py
+++ b/scripts/conversion_script.py
@@ -19,14 +19,26 @@ STATUS_CODE = {
 # Revert the `STATUS_CODE` dictionary to map number: name instead of name:
 # number as used originally.
 STATUS_CODE_NAME = {number: name for name, number in STATUS_CODE.items()}
-_C2R_LOG_FOLDER = "/var/log/convert2rhel"
+# Log folder path for convert2rhel
+C2R_LOG_FOLDER = "/var/log/convert2rhel"
+# Log file for convert2rhel
+C2R_LOG_FILE = "%s/convert2rhel.log" % C2R_LOG_FOLDER
 # Path to the convert2rhel report json file.
-C2R_REPORT_FILE = "%s/convert2rhel-pre-conversion.json" % _C2R_LOG_FOLDER
+C2R_REPORT_FILE = "%s/convert2rhel-pre-conversion.json" % C2R_LOG_FOLDER
 # Path to the convert2rhel report textual file.
-C2R_REPORT_TXT_FILE = "%s/convert2rhel-pre-conversion.txt" % _C2R_LOG_FOLDER
+C2R_REPORT_TXT_FILE = "%s/convert2rhel-pre-conversion.txt" % C2R_LOG_FOLDER
 # Path to the archive folder for convert2rhel.
-C2R_ARCHIVE_DIR = "%s/archive" % _C2R_LOG_FOLDER
+C2R_ARCHIVE_DIR = "%s/archive" % C2R_LOG_FOLDER
+# Set of yum transactions that will be rolled back after the operation is done.
 YUM_TRANSACTIONS_TO_UNDO = set()
+
+# Define regex to look for specific errors in the rollback phase in
+# convert2rhel.
+DETECT_ERROR_IN_ROLLBACK_PATTERN = re.compile(
+    r".*(error|failed|fail|failure|denied|traceback)", flags=re.MULTILINE | re.I
+)
+# Detect the last transaction id in yum.
+LATEST_YUM_TRANSACTION_PATTERN = re.compile(r"^(\s+)?(\d+)", re.MULTILINE)
 
 
 class RequiredFile(object):
@@ -86,6 +98,35 @@ class OutputCollector(object):
             "report": self.report,
             "report_json": self.report_json,
         }
+
+
+def check_for_inhibitors_in_rollback():
+    """Returns lines with errors in rollback section of c2r log file, or None."""
+    print(
+        "Checking content of '%s' for possible rollback problems ..."
+        % C2R_LOG_FILE
+    )
+    try:
+        with open(C2R_LOG_FILE, mode="r") as handler:
+            lines = handler.readlines()
+            # Find index of first string in the logs that we care about.
+            start_index = lines.index(
+                "WARNING - Abnormal exit! Performing rollback ..."
+            )
+            # Find index of last string in the logs that we care about.
+            end_index = [
+                i for i, s in enumerate(lines) if "Pre-conversion analysis report" in s
+            ][0]
+
+            actual_data = lines[start_index + 1 : end_index]
+            matches = list(filter(DETECT_ERROR_IN_ROLLBACK_PATTERN.match, actual_data))
+            if matches:
+                return "\n".join(matches)
+    except IOError:
+        print("Failed to read '%s' file.")
+        return
+
+    return
 
 
 def _check_ini_file_modified():
@@ -339,8 +380,7 @@ def _get_last_yum_transaction_id(pkg_name):
         )
         return None
 
-    pattern = re.compile(r"^(\s+)?(\d+)", re.MULTILINE)
-    matches = pattern.findall(output)
+    matches = LATEST_YUM_TRANSACTION_PATTERN.findall(output)
     return matches[-1][1] if matches else None
 
 

--- a/scripts/conversion_script.py
+++ b/scripts/conversion_script.py
@@ -659,7 +659,8 @@ def main():
                 ),
                 report=(
                     "convert2rhel exited with code %s"
-                    "Output of the failed command: %s" % (returncode, stdout.rstrip("\n"))
+                    "Output of the failed command: %s"
+                    % (returncode, stdout.rstrip("\n"))
                 ),
             )
 

--- a/scripts/conversion_script.py
+++ b/scripts/conversion_script.py
@@ -652,6 +652,22 @@ def main():
         # priority. In case the returncode was non zero, we don't care about
         # the rest and we should jump to the exception handling immediatly
         if not conversion_successful:
+            # Check if there are any inhibitors in the rollback logging. This is
+            # necessary in the case where the analysis was done successfully, but
+            # there was an error in the rollback log.
+            if rollback_errors:
+                raise ProcessError(
+                    message=(
+                        "A rollback of changes performed by convert2rhel failed. The system is in an undefined state. "
+                        "Recover the system from a backup or contact Red Hat support."
+                    ),
+                    report=(
+                        "\nFor details, refer to the convert2rhel log file on the host at "
+                        "/var/log/convert2rhel/convert2rhel.log. Relevant lines from log file: \n%s\n"
+                    )
+                    % rollback_errors,
+                )
+
             raise ProcessError(
                 message=(
                     "An error occurred during the pre-conversion analysis. For details, refer to "
@@ -662,22 +678,6 @@ def main():
                     "Output of the failed command: %s"
                     % (returncode, stdout.rstrip("\n"))
                 ),
-            )
-
-        # Check if there are any inhibitors in the rollback logging. This is
-        # necessary in the case where the analysis was done successfully, but
-        # there was an error in the rollback log.
-        if rollback_errors:
-            raise ProcessError(
-                message=(
-                    "A rollback of changes performed by convert2rhel failed. The system is in an undefined state. "
-                    "Recover the system from a backup or contact Red Hat support."
-                ),
-                report=(
-                    "\nFor details, refer to the convert2rhel log file on the host at "
-                    "/var/log/convert2rhel/convert2rhel.log. Relevant lines from log file: \n%s\n"
-                )
-                % rollback_errors,
             )
 
         print("Conversion script finished successfully!")

--- a/scripts/conversion_script.py
+++ b/scripts/conversion_script.py
@@ -109,7 +109,6 @@ def check_for_inhibitors_in_rollback():
         with open(C2R_LOG_FILE, mode="r") as handler:
             lines = [line.strip() for line in handler.readlines()]
             # Find index of first string in the logs that we care about.
-            print(lines)
             start_index = lines.index(start_of_rollback_section)
             # Find index of last string in the logs that we care about.
             end_index = [
@@ -126,6 +125,7 @@ def check_for_inhibitors_in_rollback():
         )
     except IOError:
         print("Failed to read '%s' file.")
+
     return matches
 
 
@@ -639,26 +639,41 @@ def main():
 
         stdout, returncode = run_convert2rhel()
         conversion_successful = returncode == 0
+        rollback_errors = check_for_inhibitors_in_rollback()
 
+        # Returncode other than 0 can happen in two states in analysis mode:
+        #  1. In case there is another instance of convert2rhel running
+        #  2. In case of KeyboardInterrupt, SystemExit (misplaced by mistaked),
+        #     Exception not catched before.
+        # In any case, we should treat this as separate and give it higher
+        # priority. In case the returncode was non zero, we don't care about
+        # the rest and we should jump to the exception handling immediatly
         if not conversion_successful:
-            additional_rollback_info = ""
-            rollback_errors = check_for_inhibitors_in_rollback()
-            if rollback_errors:
-                additional_rollback_info = (
+            raise ProcessError(
+                message=(
+                    "An error occurred during the pre-conversion execution. For details, refer to "
+                    "the convert2rhel log file on the host at /var/log/convert2rhel/convert2rhel.log"
+                ),
+                report=(
+                    "convert2rhel execution exited with code %s"
+                    "Output of failed command: %s" % (returncode, stdout.rstrip("\n"))
+                ),
+            )
+
+        # Check if there are any inhibitors in the rollback logging. This is
+        # necessary in the case where the analysis was done successfully, but
+        # there was an error in the rollback log.
+        if rollback_errors:
+            raise ProcessError(
+                message=(
+                    "During convert2rhel rollback, an error was identified. For details, refer to "
+                    "the convert2rhel log file on the host at /var/log/convert2rhel/convert2rhel.log"
+                ),
+                report=(
                     "\nHighlighted lines from log file related to rollback errors:\n%s\n"
-                    % rollback_errors
                 )
-            output.message = (
-                "An error occurred during the conversion execution. For details, refer to "
-                "the convert2rhel log file on the host at /var/log/convert2rhel/convert2rhel.log"
+                % rollback_errors,
             )
-            output.report = (
-                "convert2rhel execution exited with code %s"
-                "%s"
-                "Output of failed command: %s"
-                % (returncode, additional_rollback_info, stdout.rstrip("\n"))
-            )
-            return
 
         print("Conversion script finish successfully!")
     except ProcessError as exception:
@@ -716,7 +731,8 @@ def main():
             if not conversion_successful:
                 output.entries = transform_raw_data(data)
 
-        update_insights_inventory()
+            if conversion_successful:
+                update_insights_inventory()
 
         print("Cleaning up modifications to the system.")
         cleanup(required_files)

--- a/scripts/conversion_script.py
+++ b/scripts/conversion_script.py
@@ -101,18 +101,19 @@ class OutputCollector(object):
 
 
 def check_for_inhibitors_in_rollback():
-    """Returns lines with errors in rollback section of c2r log file, or None."""
+    """Returns lines with errors in rollback section of c2r log file, or empty string."""
     print(
         "Checking content of '%s' for possible rollback problems ..."
         % C2R_LOG_FILE
     )
+    matches = ""
+    start_of_rollback_section = "WARNING - Abnormal exit! Performing rollback ..."
     try:
         with open(C2R_LOG_FILE, mode="r") as handler:
-            lines = handler.readlines()
+            lines = [line.strip() for line in handler.readlines()]
             # Find index of first string in the logs that we care about.
-            start_index = lines.index(
-                "WARNING - Abnormal exit! Performing rollback ..."
-            )
+            print(lines)
+            start_index = lines.index(start_of_rollback_section)
             # Find index of last string in the logs that we care about.
             end_index = [
                 i for i, s in enumerate(lines) if "Pre-conversion analysis report" in s
@@ -120,13 +121,12 @@ def check_for_inhibitors_in_rollback():
 
             actual_data = lines[start_index + 1 : end_index]
             matches = list(filter(DETECT_ERROR_IN_ROLLBACK_PATTERN.match, actual_data))
-            if matches:
-                return "\n".join(matches)
+            matches = "\n".join(matches)
+    except ValueError:
+        print("Failed to find rollback section ('%s') in '%s' file." % (start_of_rollback_section, C2R_LOG_FILE))
     except IOError:
         print("Failed to read '%s' file.")
-        return
-
-    return
+    return matches
 
 
 def _check_ini_file_modified():

--- a/scripts/conversion_script.py
+++ b/scripts/conversion_script.py
@@ -102,10 +102,7 @@ class OutputCollector(object):
 
 def check_for_inhibitors_in_rollback():
     """Returns lines with errors in rollback section of c2r log file, or empty string."""
-    print(
-        "Checking content of '%s' for possible rollback problems ..."
-        % C2R_LOG_FILE
-    )
+    print("Checking content of '%s' for possible rollback problems ..." % C2R_LOG_FILE)
     matches = ""
     start_of_rollback_section = "WARNING - Abnormal exit! Performing rollback ..."
     try:
@@ -123,7 +120,10 @@ def check_for_inhibitors_in_rollback():
             matches = list(filter(DETECT_ERROR_IN_ROLLBACK_PATTERN.match, actual_data))
             matches = "\n".join(matches)
     except ValueError:
-        print("Failed to find rollback section ('%s') in '%s' file." % (start_of_rollback_section, C2R_LOG_FILE))
+        print(
+            "Failed to find rollback section ('%s') in '%s' file."
+            % (start_of_rollback_section, C2R_LOG_FILE)
+        )
     except IOError:
         print("Failed to read '%s' file.")
     return matches
@@ -640,13 +640,22 @@ def main():
         conversion_successful = returncode == 0
 
         if not conversion_successful:
+            additional_rollback_info = ""
+            rollback_errors = check_for_inhibitors_in_rollback()
+            if rollback_errors:
+                additional_rollback_info = (
+                    "\nHighlighted lines from log file related to rollback errors:\n%s\n"
+                    % rollback_errors
+                )
             output.message = (
                 "An error occurred during the conversion execution. For details, refer to "
                 "the convert2rhel log file on the host at /var/log/convert2rhel/convert2rhel.log"
             )
             output.report = (
-                "convert2rhel execution exited with code %s and output: %s."
-                % (returncode, stdout.rstrip("\n"))
+                "convert2rhel execution exited with code %s"
+                "%s"
+                "Output of failed command: %s"
+                % (returncode, additional_rollback_info, stdout.rstrip("\n"))
             )
             return
 

--- a/scripts/preconversion_assessment_script.py
+++ b/scripts/preconversion_assessment_script.py
@@ -35,7 +35,7 @@ YUM_TRANSACTIONS_TO_UNDO = set()
 # Define regex to look for specific errors in the rollback phase in
 # convert2rhel.
 DETECT_ERROR_IN_ROLLBACK_PATTERN = re.compile(
-    r".*(error|failed|fail|failure|denied|traceback|couldn't find a backup)",
+    r".*(error|fail|denied|traceback|couldn't find a backup)",
     flags=re.MULTILINE | re.I,
 )
 # Detect the last transaction id in yum.

--- a/scripts/preconversion_assessment_script.py
+++ b/scripts/preconversion_assessment_script.py
@@ -618,7 +618,7 @@ def main():
             YUM_TRANSACTIONS_TO_UNDO.add(transaction_id)
 
         stdout, returncode = run_convert2rhel()
-        conversion_successful = returncode == 0
+        preconversion_successful = returncode == 0
         rollback_errors = check_for_inhibitors_in_rollback()
 
         # Returncode other than 0 can happen in two states in analysis mode:
@@ -628,7 +628,7 @@ def main():
         # In any case, we should treat this as separate and give it higher
         # priority. In case the returncode was non zero, we don't care about
         # the rest and we should jump to the exception handling immediatly
-        if not conversion_successful:
+        if not preconversion_successful:
             raise ProcessError(
                 message=(
                     "An error occurred during the pre-conversion analysis. For details, refer to "

--- a/scripts/preconversion_assessment_script.py
+++ b/scripts/preconversion_assessment_script.py
@@ -573,6 +573,7 @@ def transform_raw_data(raw_data):
     return [data for data in new_data if data]
 
 
+# pylint: disable=too-many-branches
 def main():
     """Main entrypoint for the script."""
     if os.path.exists(C2R_REPORT_FILE):

--- a/scripts/preconversion_assessment_script.py
+++ b/scripts/preconversion_assessment_script.py
@@ -101,10 +101,7 @@ class OutputCollector(object):
 
 def check_for_inhibitors_in_rollback():
     """Returns lines with errors in rollback section of c2r log file, or empty string."""
-    print(
-        "Checking content of '%s' for possible rollback problems ..."
-        % C2R_LOG_FILE
-    )
+    print("Checking content of '%s' for possible rollback problems ..." % C2R_LOG_FILE)
     matches = ""
     start_of_rollback_section = "WARNING - Abnormal exit! Performing rollback ..."
     try:
@@ -122,7 +119,10 @@ def check_for_inhibitors_in_rollback():
             matches = list(filter(DETECT_ERROR_IN_ROLLBACK_PATTERN.match, actual_data))
             matches = "\n".join(matches)
     except ValueError:
-        print("Failed to find rollback section ('%s') in '%s' file." % (start_of_rollback_section, C2R_LOG_FILE))
+        print(
+            "Failed to find rollback section ('%s') in '%s' file."
+            % (start_of_rollback_section, C2R_LOG_FILE)
+        )
     except IOError:
         print("Failed to read '%s' file.")
     return matches
@@ -613,13 +613,22 @@ def main():
         stdout, returncode = run_convert2rhel()
 
         if returncode != 0:
+            additional_rollback_info = ""
+            rollback_errors = check_for_inhibitors_in_rollback()
+            if rollback_errors:
+                additional_rollback_info = (
+                    "\nHighlighted lines from log file related to  rollback errors:\n%s\n"
+                    % rollback_errors
+                )
             output.message = (
                 "An error occurred during the conversion execution. For details, refer to "
                 "the convert2rhel log file on the host at /var/log/convert2rhel/convert2rhel.log"
             )
             output.report = (
-                "convert2rhel execution exited with code %s and output: %s."
-                % (returncode, stdout.rstrip("\n"))
+                "convert2rhel execution exited with code %s"
+                "%s"
+                "Output of failed command: %s"
+                % (returncode, additional_rollback_info, stdout.rstrip("\n"))
             )
             return
 

--- a/scripts/preconversion_assessment_script.py
+++ b/scripts/preconversion_assessment_script.py
@@ -596,7 +596,7 @@ def main():
     ]
 
     # Flag that indicate if the conversion was successful or not.
-    conversion_successful = False
+    preconversion_successful = False
     # String to hold any errors that happened during rollback.
     rollback_errors = ""
 
@@ -631,12 +631,12 @@ def main():
         if not conversion_successful:
             raise ProcessError(
                 message=(
-                    "An error occurred during the pre-conversion execution. For details, refer to "
+                    "An error occurred during the pre-conversion analysis. For details, refer to "
                     "the convert2rhel log file on the host at /var/log/convert2rhel/convert2rhel.log"
                 ),
                 report=(
-                    "convert2rhel execution exited with code %s"
-                    "Output of failed command: %s" % (returncode, stdout.rstrip("\n"))
+                    "convert2rhel exited with code %s"
+                    "Output of the failed command: %s" % (returncode, stdout.rstrip("\n"))
                 ),
             )
 

--- a/scripts/preconversion_assessment_script.py
+++ b/scripts/preconversion_assessment_script.py
@@ -636,7 +636,8 @@ def main():
                 ),
                 report=(
                     "convert2rhel exited with code %s"
-                    "Output of the failed command: %s" % (returncode, stdout.rstrip("\n"))
+                    "Output of the failed command: %s"
+                    % (returncode, stdout.rstrip("\n"))
                 ),
             )
 

--- a/tests/conversion_script/test_check_rollback_inhibitors.py
+++ b/tests/conversion_script/test_check_rollback_inhibitors.py
@@ -64,3 +64,26 @@ def test_io_error(mock_open_fn):
     result = check_for_inhibitors_in_rollback()
     mock_open_fn.assert_called_once()
     assert result == ""
+
+
+@patch(
+    "__builtin__.open",
+    new_callable=mock_open,
+    read_data="\n".join(
+        [
+            "Some lines before the warning",
+            "WARNING - Abnormal exit! Performing rollback ...",
+            "WARNING - Couldn't find a backup for centos-logos-70.0.6-3.el7.centos.noarch package.",
+            "WARNING - Couldn't find a backup for centos-release-7-9.2009.1.el7.centos.x86_64 package.",
+            "Pre-conversion analysis report",
+            "Some lines after the report",
+        ]
+    ),
+)
+def test_match_backup_warning(mock_open_fn):
+    result = check_for_inhibitors_in_rollback()
+    mock_open_fn.assert_called_once()
+    assert (
+        result
+        == "WARNING - Couldn't find a backup for centos-logos-70.0.6-3.el7.centos.noarch package.\nWARNING - Couldn't find a backup for centos-release-7-9.2009.1.el7.centos.x86_64 package."
+    )

--- a/tests/conversion_script/test_check_rollback_inhibitors.py
+++ b/tests/conversion_script/test_check_rollback_inhibitors.py
@@ -27,6 +27,25 @@ def test_rollback_with_errors(mock_open_fn):
 @patch(
     "__builtin__.open",
     new_callable=mock_open,
+    read_data="\n".join(
+        [
+            "Some lines before the warning",
+            "WARNING - Abnormal exit! Performing rollback ...",
+            "test-blabla",
+            "Pre-conversion analysis report",
+            "Some lines after the report",
+        ]
+    ),
+)
+def test_rollback_with_no_matches(mock_open_fn):
+    result = check_for_inhibitors_in_rollback()
+    mock_open_fn.assert_called_once()
+    assert result == ""
+
+
+@patch(
+    "__builtin__.open",
+    new_callable=mock_open,
     read_data="".join(
         [
             "No warning or report",

--- a/tests/conversion_script/test_check_rollback_inhibitors.py
+++ b/tests/conversion_script/test_check_rollback_inhibitors.py
@@ -1,0 +1,34 @@
+from mock import patch, mock_open
+
+
+from scripts.conversion_script import (
+    check_for_inhibitors_in_rollback
+)
+
+@patch("__builtin__.open", new_callable=mock_open, read_data="\n".join([
+    "Some lines before the warning",
+    "WARNING - Abnormal exit! Performing rollback ...",
+    "Error message 1",
+    "Error message 2",
+    "Pre-conversion analysis report",
+    "Some lines after the report",
+]))
+def test_rollback_with_errors(mock_open_fn):
+    result = check_for_inhibitors_in_rollback()
+    mock_open_fn.assert_called_once()
+    assert result == "Error message 1\nError message 2"
+
+@patch("__builtin__.open", new_callable=mock_open, read_data="".join([
+    "No warning or report",
+    "No errors here",
+]))
+def test_no_rollback_section_value_error(mock_open_fn):
+    result = check_for_inhibitors_in_rollback()
+    mock_open_fn.assert_called_once()
+    assert result == ""
+
+@patch("__builtin__.open", side_effect=IOError("File not found"))
+def test_io_error(mock_open_fn):
+    result = check_for_inhibitors_in_rollback()
+    mock_open_fn.assert_called_once()
+    assert result == ""

--- a/tests/conversion_script/test_check_rollback_inhibitors.py
+++ b/tests/conversion_script/test_check_rollback_inhibitors.py
@@ -1,31 +1,44 @@
 from mock import patch, mock_open
 
 
-from scripts.conversion_script import (
-    check_for_inhibitors_in_rollback
-)
+from scripts.conversion_script import check_for_inhibitors_in_rollback
 
-@patch("__builtin__.open", new_callable=mock_open, read_data="\n".join([
-    "Some lines before the warning",
-    "WARNING - Abnormal exit! Performing rollback ...",
-    "Error message 1",
-    "Error message 2",
-    "Pre-conversion analysis report",
-    "Some lines after the report",
-]))
+
+@patch(
+    "__builtin__.open",
+    new_callable=mock_open,
+    read_data="\n".join(
+        [
+            "Some lines before the warning",
+            "WARNING - Abnormal exit! Performing rollback ...",
+            "Error message 1",
+            "Error message 2",
+            "Pre-conversion analysis report",
+            "Some lines after the report",
+        ]
+    ),
+)
 def test_rollback_with_errors(mock_open_fn):
     result = check_for_inhibitors_in_rollback()
     mock_open_fn.assert_called_once()
     assert result == "Error message 1\nError message 2"
 
-@patch("__builtin__.open", new_callable=mock_open, read_data="".join([
-    "No warning or report",
-    "No errors here",
-]))
+
+@patch(
+    "__builtin__.open",
+    new_callable=mock_open,
+    read_data="".join(
+        [
+            "No warning or report",
+            "No errors here",
+        ]
+    ),
+)
 def test_no_rollback_section_value_error(mock_open_fn):
     result = check_for_inhibitors_in_rollback()
     mock_open_fn.assert_called_once()
     assert result == ""
+
 
 @patch("__builtin__.open", side_effect=IOError("File not found"))
 def test_io_error(mock_open_fn):

--- a/tests/conversion_script/test_main.py
+++ b/tests/conversion_script/test_main.py
@@ -27,7 +27,7 @@ def test_main_non_eligible_release(
     mock_output_collector.assert_called()
     mock_cleanup.assert_called_once()
     assert mock_archive_analysis_report.call_count == 0
-    mock_update_insights_inventory.assert_called_once()
+    assert mock_update_insights_inventory.call_count == 0
 
 
 # fmt: off
@@ -189,13 +189,10 @@ def test_main_inhibited_c2r_installed(
     mock_setup_convert2rhel,
     mock_update_insights_inventory,
     mock_gather_json_report,
-    capsys,  # to check for rollback info in stdout
 ):
     main()
 
     mock_rollback_inhibitor_check.assert_called_once()
-    captured = capsys.readouterr()
-    assert "rollback" not in captured.out
 
     assert mock_get_system_distro_version.call_count == 1
     assert mock_is_eligible_releases.call_count == 1
@@ -212,7 +209,7 @@ def test_main_inhibited_c2r_installed(
     # 2x in cleanup + 2x for archive
     assert mock_os_exists.call_count == 4
     assert mock_cleanup_file_restore_call.call_count == 2
-    assert mock_update_insights_inventory.call_count == 1
+    assert mock_update_insights_inventory.call_count == 0
 
 
 # fmt: off
@@ -260,7 +257,7 @@ def test_main_process_error(
     assert mock_gather_textual_report.call_count == 0
     assert mock_generate_report_message.call_count == 0
     assert mock_cleanup.call_count == 1
-    assert mock_update_insights_inventory.call_count == 1
+    assert mock_update_insights_inventory.call_count == 0
 
 
 # fmt: off
@@ -305,7 +302,7 @@ def test_main_general_exception(
     assert mock_gather_textual_report.call_count == 0
     assert mock_generate_report_message.call_count == 0
     assert mock_cleanup.call_count == 1
-    assert mock_update_insights_inventory.call_count == 1
+    assert mock_update_insights_inventory.call_count == 0
 
 
 # fmt: off
@@ -353,7 +350,7 @@ def test_main_inhibited_ini_modified(
     assert mock_gather_textual_report.call_count == 0
     assert mock_generate_report_message.call_count == 0
     assert mock_cleanup.call_count == 1
-    assert mock_update_insights_inventory.call_count == 1
+    assert mock_update_insights_inventory.call_count == 0
 
 
 # fmt: off
@@ -401,7 +398,7 @@ def test_main_inhibited_custom_ini(
     assert mock_gather_textual_report.call_count == 0
     assert mock_generate_report_message.call_count == 0
     assert mock_cleanup.call_count == 1
-    assert mock_update_insights_inventory.call_count == 1
+    assert mock_update_insights_inventory.call_count == 0
 
 
 # fmt: off
@@ -441,14 +438,10 @@ def test_main_inhibited_c2r_installed_rollback_errors(
     mock_setup_convert2rhel,
     mock_update_insights_inventory,
     mock_gather_json_report,
-    capsys,  # to check for rollback info in stdout
 ):
     main()
 
-    captured = capsys.readouterr()
     mock_rollback_inhibitor_check.assert_called_once()
-    assert "rollback" in captured.out
-
     assert mock_get_system_distro_version.call_count == 1
     assert mock_is_eligible_releases.call_count == 1
     assert mock_inhibitor_check.call_count == 1
@@ -457,11 +450,11 @@ def test_main_inhibited_c2r_installed_rollback_errors(
     assert mock_run_convert2rhel.call_count == 1
     assert mock_gather_json_report.call_count == 1
     assert mock_find_highest_report_level.call_count == 1
-    assert mock_transform_raw_data.call_count == 1
+    assert mock_transform_raw_data.call_count == 0
     assert mock_gather_textual_report.call_count == 0
     assert mock_generate_report_message.call_count == 0
     assert mock_cleanup_pkg_call.call_count == 1
     # 2x in cleanup + 2x for archive
     assert mock_os_exists.call_count == 4
     assert mock_cleanup_file_restore_call.call_count == 2
-    assert mock_update_insights_inventory.call_count == 1
+    assert mock_update_insights_inventory.call_count == 0

--- a/tests/conversion_script/test_main.py
+++ b/tests/conversion_script/test_main.py
@@ -172,7 +172,7 @@ def test_main_success_c2r_updated(
 @patch("scripts.conversion_script.check_for_inhibitors_in_rollback", return_value="")
 # fmt: on
 # pylint: disable=too-many-locals
-def test_main_inhibited_c2r_installed(
+def test_main_inhibited_c2r_installed_no_rollback_err(
     mock_rollback_inhibitor_check,
     mock_is_eligible_releases,
     mock_get_system_distro_version,

--- a/tests/conversion_script/test_main.py
+++ b/tests/conversion_script/test_main.py
@@ -158,7 +158,7 @@ def test_main_success_c2r_updated(
 @patch("scripts.conversion_script.setup_convert2rhel", side_effect=Mock())
 @patch("scripts.conversion_script.check_convert2rhel_inhibitors_before_run", return_value=("", 0))
 @patch("scripts.conversion_script.install_convert2rhel", return_value=(True, 1))
-@patch("scripts.conversion_script.run_convert2rhel", return_value=("", 0))
+@patch("scripts.conversion_script.run_convert2rhel", return_value=("", 1))
 @patch("scripts.conversion_script.find_highest_report_level", side_effect=Mock(return_value=["SUCCESS"]))
 @patch("scripts.conversion_script.gather_textual_report", side_effect=Mock(return_value=""))
 @patch("scripts.conversion_script.generate_report_message", side_effect=Mock(return_value=("inhibited", False)))
@@ -169,8 +169,10 @@ def test_main_success_c2r_updated(
 @patch("scripts.conversion_script.run_subprocess", return_value=("", 1))
 @patch("scripts.conversion_script.get_system_distro_version", return_value=("centos", "7.9"))
 @patch("scripts.conversion_script.is_eligible_releases", return_value=True)
+@patch("scripts.conversion_script.check_for_inhibitors_in_rollback", return_value="")
 # fmt: on
 def test_main_inhibited_c2r_installed(
+    mock_rollback_inhibitor_check,
     mock_is_eligible_releases,
     mock_get_system_distro_version,
     mock_cleanup_pkg_call,
@@ -186,8 +188,13 @@ def test_main_inhibited_c2r_installed(
     mock_setup_convert2rhel,
     mock_update_insights_inventory,
     mock_gather_json_report,
+    capsys,  # to check for rollback info in stdout
 ):
     main()
+
+    mock_rollback_inhibitor_check.assert_called_once()
+    captured = capsys.readouterr()
+    assert "rollback" not in captured.out
 
     assert mock_get_system_distro_version.call_count == 1
     assert mock_is_eligible_releases.call_count == 1
@@ -197,9 +204,9 @@ def test_main_inhibited_c2r_installed(
     assert mock_run_convert2rhel.call_count == 1
     assert mock_gather_json_report.call_count == 1
     assert mock_find_highest_report_level.call_count == 1
-    assert mock_transform_raw_data.call_count == 0
+    assert mock_transform_raw_data.call_count == 1
     assert mock_gather_textual_report.call_count == 0
-    assert mock_generate_report_message.call_count == 1
+    assert mock_generate_report_message.call_count == 0
     assert mock_cleanup_pkg_call.call_count == 1
     # 2x in cleanup + 2x for archive
     assert mock_os_exists.call_count == 4
@@ -393,4 +400,66 @@ def test_main_inhibited_custom_ini(
     assert mock_gather_textual_report.call_count == 0
     assert mock_generate_report_message.call_count == 0
     assert mock_cleanup.call_count == 1
+    assert mock_update_insights_inventory.call_count == 1
+
+
+# fmt: off
+@patch("scripts.conversion_script.gather_json_report", side_effect=[{"actions": []}])
+@patch("scripts.conversion_script.update_insights_inventory", side_effect=Mock())
+@patch("scripts.conversion_script.setup_convert2rhel", side_effect=Mock())
+@patch("scripts.conversion_script.check_convert2rhel_inhibitors_before_run", return_value=("", 0))
+@patch("scripts.conversion_script.install_convert2rhel", return_value=(True, 1))
+@patch("scripts.conversion_script.run_convert2rhel", return_value=("", 1))
+@patch("scripts.conversion_script.find_highest_report_level", side_effect=Mock(return_value=["SUCCESS"]))
+@patch("scripts.conversion_script.gather_textual_report", side_effect=Mock(return_value=""))
+@patch("scripts.conversion_script.generate_report_message", side_effect=Mock(return_value=("inhibited", False)))
+@patch("scripts.conversion_script.transform_raw_data", side_effect=Mock(return_value=""))
+# These patches are calls made in cleanup
+@patch("os.path.exists", return_value=False)
+@patch("scripts.conversion_script._create_or_restore_backup_file", side_effect=Mock())
+@patch("scripts.conversion_script.run_subprocess", return_value=("", 1))
+@patch("scripts.conversion_script.get_system_distro_version", return_value=("centos", "7.9"))
+@patch("scripts.conversion_script.is_eligible_releases", return_value=True)
+@patch("scripts.conversion_script.check_for_inhibitors_in_rollback", return_value="rollback error")
+# fmt: on
+def test_main_inhibited_c2r_installed_rollback_errors(
+    mock_rollback_inhibitor_check,
+    mock_is_eligible_releases,
+    mock_get_system_distro_version,
+    mock_cleanup_pkg_call,
+    mock_cleanup_file_restore_call,
+    mock_os_exists,
+    mock_transform_raw_data,
+    mock_generate_report_message,
+    mock_gather_textual_report,
+    mock_find_highest_report_level,
+    mock_run_convert2rhel,
+    mock_inhibitor_check,
+    mock_install_convert2rhel,
+    mock_setup_convert2rhel,
+    mock_update_insights_inventory,
+    mock_gather_json_report,
+    capsys,  # to check for rollback info in stdout
+):
+    main()
+
+    captured = capsys.readouterr()
+    mock_rollback_inhibitor_check.assert_called_once()
+    assert "rollback" in captured.out
+
+    assert mock_get_system_distro_version.call_count == 1
+    assert mock_is_eligible_releases.call_count == 1
+    assert mock_inhibitor_check.call_count == 1
+    assert mock_setup_convert2rhel.call_count == 1
+    assert mock_install_convert2rhel.call_count == 1
+    assert mock_run_convert2rhel.call_count == 1
+    assert mock_gather_json_report.call_count == 1
+    assert mock_find_highest_report_level.call_count == 1
+    assert mock_transform_raw_data.call_count == 1
+    assert mock_gather_textual_report.call_count == 0
+    assert mock_generate_report_message.call_count == 0
+    assert mock_cleanup_pkg_call.call_count == 1
+    # 2x in cleanup + 2x for archive
+    assert mock_os_exists.call_count == 4
+    assert mock_cleanup_file_restore_call.call_count == 2
     assert mock_update_insights_inventory.call_count == 1

--- a/tests/conversion_script/test_main.py
+++ b/tests/conversion_script/test_main.py
@@ -171,6 +171,7 @@ def test_main_success_c2r_updated(
 @patch("scripts.conversion_script.is_eligible_releases", return_value=True)
 @patch("scripts.conversion_script.check_for_inhibitors_in_rollback", return_value="")
 # fmt: on
+# pylint: disable=too-many-locals
 def test_main_inhibited_c2r_installed(
     mock_rollback_inhibitor_check,
     mock_is_eligible_releases,
@@ -422,6 +423,7 @@ def test_main_inhibited_custom_ini(
 @patch("scripts.conversion_script.is_eligible_releases", return_value=True)
 @patch("scripts.conversion_script.check_for_inhibitors_in_rollback", return_value="rollback error")
 # fmt: on
+# pylint: disable=too-many-locals
 def test_main_inhibited_c2r_installed_rollback_errors(
     mock_rollback_inhibitor_check,
     mock_is_eligible_releases,

--- a/tests/preconversion_assessment/test_check_rollback_inhibitors.py
+++ b/tests/preconversion_assessment/test_check_rollback_inhibitors.py
@@ -64,3 +64,26 @@ def test_io_error(mock_open_fn):
     result = check_for_inhibitors_in_rollback()
     mock_open_fn.assert_called_once()
     assert result == ""
+
+
+@patch(
+    "__builtin__.open",
+    new_callable=mock_open,
+    read_data="\n".join(
+        [
+            "Some lines before the warning",
+            "WARNING - Abnormal exit! Performing rollback ...",
+            "WARNING - Couldn't find a backup for centos-logos-70.0.6-3.el7.centos.noarch package.",
+            "WARNING - Couldn't find a backup for centos-release-7-9.2009.1.el7.centos.x86_64 package.",
+            "Pre-conversion analysis report",
+            "Some lines after the report",
+        ]
+    ),
+)
+def test_match_backup_warning(mock_open_fn):
+    result = check_for_inhibitors_in_rollback()
+    mock_open_fn.assert_called_once()
+    assert (
+        result
+        == "WARNING - Couldn't find a backup for centos-logos-70.0.6-3.el7.centos.noarch package.\nWARNING - Couldn't find a backup for centos-release-7-9.2009.1.el7.centos.x86_64 package."
+    )

--- a/tests/preconversion_assessment/test_check_rollback_inhibitors.py
+++ b/tests/preconversion_assessment/test_check_rollback_inhibitors.py
@@ -1,0 +1,34 @@
+from mock import patch, mock_open
+
+
+from scripts.preconversion_assessment_script import (
+    check_for_inhibitors_in_rollback
+)
+
+@patch("__builtin__.open", new_callable=mock_open, read_data="\n".join([
+    "Some lines before the warning",
+    "WARNING - Abnormal exit! Performing rollback ...",
+    "Error message 1",
+    "Error message 2",
+    "Pre-conversion analysis report",
+    "Some lines after the report",
+]))
+def test_rollback_with_errors(mock_open_fn):
+    result = check_for_inhibitors_in_rollback()
+    mock_open_fn.assert_called_once()
+    assert result == "Error message 1\nError message 2"
+
+@patch("__builtin__.open", new_callable=mock_open, read_data="".join([
+    "No warning or report",
+    "No errors here",
+]))
+def test_no_rollback_section_value_error(mock_open_fn):
+    result = check_for_inhibitors_in_rollback()
+    mock_open_fn.assert_called_once()
+    assert result == ""
+
+@patch("__builtin__.open", side_effect=IOError("File not found"))
+def test_io_error(mock_open_fn):
+    result = check_for_inhibitors_in_rollback()
+    mock_open_fn.assert_called_once()
+    assert result == ""

--- a/tests/preconversion_assessment/test_check_rollback_inhibitors.py
+++ b/tests/preconversion_assessment/test_check_rollback_inhibitors.py
@@ -27,6 +27,25 @@ def test_rollback_with_errors(mock_open_fn):
 @patch(
     "__builtin__.open",
     new_callable=mock_open,
+    read_data="\n".join(
+        [
+            "Some lines before the warning",
+            "WARNING - Abnormal exit! Performing rollback ...",
+            "test-blabla",
+            "Pre-conversion analysis report",
+            "Some lines after the report",
+        ]
+    ),
+)
+def test_rollback_with_no_matches(mock_open_fn):
+    result = check_for_inhibitors_in_rollback()
+    mock_open_fn.assert_called_once()
+    assert result == ""
+
+
+@patch(
+    "__builtin__.open",
+    new_callable=mock_open,
     read_data="".join(
         [
             "No warning or report",

--- a/tests/preconversion_assessment/test_check_rollback_inhibitors.py
+++ b/tests/preconversion_assessment/test_check_rollback_inhibitors.py
@@ -1,31 +1,44 @@
 from mock import patch, mock_open
 
 
-from scripts.preconversion_assessment_script import (
-    check_for_inhibitors_in_rollback
-)
+from scripts.preconversion_assessment_script import check_for_inhibitors_in_rollback
 
-@patch("__builtin__.open", new_callable=mock_open, read_data="\n".join([
-    "Some lines before the warning",
-    "WARNING - Abnormal exit! Performing rollback ...",
-    "Error message 1",
-    "Error message 2",
-    "Pre-conversion analysis report",
-    "Some lines after the report",
-]))
+
+@patch(
+    "__builtin__.open",
+    new_callable=mock_open,
+    read_data="\n".join(
+        [
+            "Some lines before the warning",
+            "WARNING - Abnormal exit! Performing rollback ...",
+            "Error message 1",
+            "Error message 2",
+            "Pre-conversion analysis report",
+            "Some lines after the report",
+        ]
+    ),
+)
 def test_rollback_with_errors(mock_open_fn):
     result = check_for_inhibitors_in_rollback()
     mock_open_fn.assert_called_once()
     assert result == "Error message 1\nError message 2"
 
-@patch("__builtin__.open", new_callable=mock_open, read_data="".join([
-    "No warning or report",
-    "No errors here",
-]))
+
+@patch(
+    "__builtin__.open",
+    new_callable=mock_open,
+    read_data="".join(
+        [
+            "No warning or report",
+            "No errors here",
+        ]
+    ),
+)
 def test_no_rollback_section_value_error(mock_open_fn):
     result = check_for_inhibitors_in_rollback()
     mock_open_fn.assert_called_once()
     assert result == ""
+
 
 @patch("__builtin__.open", side_effect=IOError("File not found"))
 def test_io_error(mock_open_fn):

--- a/tests/preconversion_assessment/test_gather_report.py
+++ b/tests/preconversion_assessment/test_gather_report.py
@@ -47,7 +47,7 @@ def test_gather_json_report_bad_content(content, expected, tmpdir):
     file = tmpdir.join("report.json")
     file.write(content)
     file = str(file)
-    with patch("scripts.conversion_script.C2R_REPORT_FILE", file):
+    with patch("scripts.preconversion_assessment_script.C2R_REPORT_FILE", file):
         assert gather_json_report() == expected
 
 

--- a/tests/preconversion_assessment/test_main.py
+++ b/tests/preconversion_assessment/test_main.py
@@ -30,7 +30,7 @@ def test_main_non_eligible_release(
 @patch("scripts.preconversion_assessment_script.setup_convert2rhel", side_effect=Mock())
 @patch("scripts.preconversion_assessment_script.install_convert2rhel", return_value=(False, 1))
 @patch("scripts.preconversion_assessment_script.check_convert2rhel_inhibitors_before_run", return_value=("", 0))
-@patch("scripts.preconversion_assessment_script.run_convert2rhel", side_effect=Mock())
+@patch("scripts.preconversion_assessment_script.run_convert2rhel", return_value=("", 0))
 @patch("scripts.preconversion_assessment_script.find_highest_report_level", side_effect=Mock(return_value=["SUCCESS"]))
 @patch("scripts.preconversion_assessment_script.gather_textual_report", side_effect=Mock(return_value=""))
 @patch("scripts.preconversion_assessment_script.generate_report_message", side_effect=Mock(return_value=("successfully", False)))
@@ -39,8 +39,10 @@ def test_main_non_eligible_release(
 @patch("scripts.preconversion_assessment_script.get_system_distro_version", return_value=("centos", "7.9"))
 @patch("scripts.preconversion_assessment_script.is_eligible_releases", return_value=True)
 @patch("scripts.preconversion_assessment_script.archive_analysis_report", side_effect=Mock())
+@patch("scripts.preconversion_assessment_script.check_for_inhibitors_in_rollback", return_value="")
 # fmt: on
 def test_main_success_c2r_installed(
+    mock_rollback_inhibitor_check,
     mock_archive_analysis_report,
     mock_is_eligible_releases,
     mock_get_system_distro_version,
@@ -54,8 +56,13 @@ def test_main_success_c2r_installed(
     mock_install_convert2rhel,
     mock_setup_convert2rhel,
     mock_gather_json_report,
+    capsys,  # to check for rollback info in stdout
 ):
     main()
+
+    captured = capsys.readouterr()
+    assert "rollback" not in captured.out
+    mock_rollback_inhibitor_check.assert_not_called()
 
     assert mock_setup_convert2rhel.call_count == 1
     assert mock_install_convert2rhel.call_count == 1
@@ -63,8 +70,8 @@ def test_main_success_c2r_installed(
     assert mock_run_convert2rhel.call_count == 1
     assert mock_gather_json_report.call_count == 1
     assert mock_find_highest_report_level.call_count == 1
-    assert mock_gather_textual_report.call_count == 0
-    assert mock_generate_report_message.call_count == 0
+    assert mock_gather_textual_report.call_count == 1
+    assert mock_generate_report_message.call_count == 1
     assert mock_cleanup.call_count == 1
     assert mock_transform_raw_data.call_count == 1
     assert mock_get_system_distro_version.call_count == 1
@@ -247,3 +254,58 @@ def test_main_inhibited_custom_ini(
     assert mock_get_system_distro_version.call_count == 1
     assert mock_is_eligible_releases.call_count == 1
     assert mock_archive_analysis_report.call_count == 2
+
+
+# fmt: off
+@patch("scripts.preconversion_assessment_script.gather_json_report", side_effect=[{"actions": []}])
+@patch("scripts.preconversion_assessment_script.setup_convert2rhel", side_effect=Mock())
+@patch("scripts.preconversion_assessment_script.install_convert2rhel", return_value=(False, 1))
+@patch("scripts.preconversion_assessment_script.check_convert2rhel_inhibitors_before_run", return_value=("", 0))
+@patch("scripts.preconversion_assessment_script.run_convert2rhel", return_value=("", 1))
+@patch("scripts.preconversion_assessment_script.find_highest_report_level", side_effect=Mock(return_value=["SUCCESS"]))
+@patch("scripts.preconversion_assessment_script.gather_textual_report", side_effect=Mock(return_value=""))
+@patch("scripts.preconversion_assessment_script.generate_report_message", side_effect=Mock(return_value=("successfully", False)))
+@patch("scripts.preconversion_assessment_script.transform_raw_data", side_effect=Mock(return_value=""))
+@patch("scripts.preconversion_assessment_script.cleanup", side_effect=Mock())
+@patch("scripts.preconversion_assessment_script.get_system_distro_version", return_value=("centos", "7.9"))
+@patch("scripts.preconversion_assessment_script.is_eligible_releases", return_value=True)
+@patch("scripts.preconversion_assessment_script.archive_analysis_report", side_effect=Mock())
+@patch("scripts.preconversion_assessment_script.check_for_inhibitors_in_rollback", return_value="rollback error")
+# fmt: on
+def test_main_inhibited_c2r_installed(
+    mock_rollback_inhibitor_check,
+    mock_archive_analysis_report,
+    mock_is_eligible_releases,
+    mock_get_system_distro_version,
+    mock_cleanup,
+    mock_transform_raw_data,
+    mock_generate_report_message,
+    mock_gather_textual_report,
+    mock_find_highest_report_level,
+    mock_run_convert2rhel,
+    mock_inhibitor_check,
+    mock_install_convert2rhel,
+    mock_setup_convert2rhel,
+    mock_gather_json_report,
+    capsys,  # to check for rollback info in stdout
+):
+    main()
+
+    captured = capsys.readouterr()
+    assert "rollback" in captured.out
+    mock_rollback_inhibitor_check.assert_called_once()
+
+    assert mock_setup_convert2rhel.call_count == 1
+    assert mock_install_convert2rhel.call_count == 1
+    assert mock_inhibitor_check.call_count == 1
+    assert mock_run_convert2rhel.call_count == 1
+    assert mock_gather_json_report.call_count == 1
+    assert mock_find_highest_report_level.call_count == 1
+    assert mock_gather_textual_report.call_count == 0
+    assert mock_generate_report_message.call_count == 0
+    assert mock_cleanup.call_count == 1
+    assert mock_transform_raw_data.call_count == 1
+    assert mock_get_system_distro_version.call_count == 1
+    assert mock_is_eligible_releases.call_count == 1
+    assert mock_archive_analysis_report.call_count == 0
+    assert mock_transform_raw_data.call_count == 1

--- a/tests/preconversion_assessment/test_main.py
+++ b/tests/preconversion_assessment/test_main.py
@@ -63,7 +63,7 @@ def test_main_success_c2r_installed(
 
     captured = capsys.readouterr()
     assert "rollback" not in captured.out
-    mock_rollback_inhibitor_check.assert_not_called()
+    assert mock_rollback_inhibitor_check.call_count == 1
 
     assert mock_setup_convert2rhel.call_count == 1
     assert mock_install_convert2rhel.call_count == 1
@@ -289,12 +289,8 @@ def test_main_inhibited_c2r_installed(
     mock_install_convert2rhel,
     mock_setup_convert2rhel,
     mock_gather_json_report,
-    capsys,  # to check for rollback info in stdout
 ):
     main()
-
-    captured = capsys.readouterr()
-    assert "rollback" in captured.out
     mock_rollback_inhibitor_check.assert_called_once()
 
     assert mock_setup_convert2rhel.call_count == 1
@@ -306,8 +302,7 @@ def test_main_inhibited_c2r_installed(
     assert mock_gather_textual_report.call_count == 0
     assert mock_generate_report_message.call_count == 0
     assert mock_cleanup.call_count == 1
-    assert mock_transform_raw_data.call_count == 1
+    assert mock_transform_raw_data.call_count == 0
     assert mock_get_system_distro_version.call_count == 1
     assert mock_is_eligible_releases.call_count == 1
     assert mock_archive_analysis_report.call_count == 0
-    assert mock_transform_raw_data.call_count == 1

--- a/tests/preconversion_assessment/test_main.py
+++ b/tests/preconversion_assessment/test_main.py
@@ -274,7 +274,7 @@ def test_main_inhibited_custom_ini(
 @patch("scripts.preconversion_assessment_script.check_for_inhibitors_in_rollback", return_value="rollback error")
 # fmt: on
 # pylint: disable=too-many-locals
-def test_main_inhibited_c2r_installed(
+def test_main_inhibited_c2r_installed_rollback_errors(
     mock_rollback_inhibitor_check,
     mock_archive_analysis_report,
     mock_is_eligible_releases,

--- a/tests/preconversion_assessment/test_main.py
+++ b/tests/preconversion_assessment/test_main.py
@@ -41,6 +41,7 @@ def test_main_non_eligible_release(
 @patch("scripts.preconversion_assessment_script.archive_analysis_report", side_effect=Mock())
 @patch("scripts.preconversion_assessment_script.check_for_inhibitors_in_rollback", return_value="")
 # fmt: on
+# pylint: disable=too-many-locals
 def test_main_success_c2r_installed(
     mock_rollback_inhibitor_check,
     mock_archive_analysis_report,
@@ -272,6 +273,7 @@ def test_main_inhibited_custom_ini(
 @patch("scripts.preconversion_assessment_script.archive_analysis_report", side_effect=Mock())
 @patch("scripts.preconversion_assessment_script.check_for_inhibitors_in_rollback", return_value="rollback error")
 # fmt: on
+# pylint: disable=too-many-locals
 def test_main_inhibited_c2r_installed(
     mock_rollback_inhibitor_check,
     mock_archive_analysis_report,


### PR DESCRIPTION
This work introduces a way to detect errors that may occur during the rollback phase of convert2rhel. This will try to detect if something went wrong based on a few keywords that we know that could appear.

Resolves: https://issues.redhat.com/browse/HMS-3128