### PR TITLE
Check for custom and modified ini after convert2rhel update/install

### DIFF
--- a/scripts/conversion_script.py
+++ b/scripts/conversion_script.py
@@ -635,11 +635,11 @@ def main():
 
         # Setup Convert2RHEL to be executed.
         setup_convert2rhel(required_files)
-        check_convert2rhel_inhibitors_before_run()
         convert2rhel_installed, transaction_id = install_convert2rhel()
         if convert2rhel_installed:
             YUM_TRANSACTIONS_TO_UNDO.add(transaction_id)
 
+        check_convert2rhel_inhibitors_before_run()
         stdout, returncode = run_convert2rhel()
         conversion_successful = returncode == 0
         rollback_errors = check_for_inhibitors_in_rollback()

--- a/scripts/preconversion_assessment_script.py
+++ b/scripts/preconversion_assessment_script.py
@@ -612,11 +612,11 @@ def main():
 
         # Setup Convert2RHEL to be executed.
         setup_convert2rhel(required_files)
-        check_convert2rhel_inhibitors_before_run()
         installed, transaction_id = install_convert2rhel()
         if installed:
             YUM_TRANSACTIONS_TO_UNDO.add(transaction_id)
 
+        check_convert2rhel_inhibitors_before_run()
         stdout, returncode = run_convert2rhel()
         preconversion_successful = returncode == 0
         rollback_errors = check_for_inhibitors_in_rollback()

--- a/tests/conversion_script/test_main.py
+++ b/tests/conversion_script/test_main.py
@@ -320,7 +320,7 @@ def test_main_general_exception(
 
 # fmt: off
 @patch("scripts.conversion_script.setup_convert2rhel", side_effect=Mock())
-@patch("scripts.conversion_script.install_convert2rhel", side_effect=Mock())
+@patch("scripts.conversion_script.install_convert2rhel", return_value=(True, 1))
 @patch("os.path.exists", return_value=False)
 @patch("scripts.conversion_script._check_ini_file_modified", return_value=True)
 @patch("scripts.conversion_script.run_convert2rhel", side_effect=Mock())
@@ -362,7 +362,7 @@ def test_main_inhibited_ini_modified(
     assert mock_custom_ini.call_count == 1
     # 2x for archive check + 1 inside in inhibitor check + 1 gather json
     assert mock_os_exists.call_count == 4
-    assert mock_install_convert2rhel.call_count == 0
+    assert mock_install_convert2rhel.call_count == 1
     assert mock_run_convert2rhel.call_count == 0
     assert mock_find_highest_report_level.call_count == 0
     assert mock_gather_textual_report.call_count == 0
@@ -374,7 +374,7 @@ def test_main_inhibited_ini_modified(
 # fmt: off
 @patch("scripts.conversion_script.gather_json_report", side_effect=Mock(return_value={}))
 @patch("scripts.conversion_script.setup_convert2rhel", side_effect=Mock())
-@patch("scripts.conversion_script.install_convert2rhel", side_effect=Mock())
+@patch("scripts.conversion_script.install_convert2rhel", return_value=(True, 1))
 @patch("os.path.exists", return_value=True)
 @patch("scripts.conversion_script.run_convert2rhel", side_effect=Mock())
 @patch("scripts.conversion_script.find_highest_report_level", side_effect=Mock(return_value=["SUCCESS"]))
@@ -414,7 +414,7 @@ def test_main_inhibited_custom_ini(
     assert mock_setup_convert2rhel.call_count == 1
     # Twice for archiving reports + 1 inside inhibitor check
     assert mock_os_exists.call_count == 3
-    assert mock_install_convert2rhel.call_count == 0
+    assert mock_install_convert2rhel.call_count == 1
     assert mock_run_convert2rhel.call_count == 0
     assert mock_gather_json_report.call_count == 1
     assert mock_find_highest_report_level.call_count == 0

--- a/tests/preconversion_assessment/test_main.py
+++ b/tests/preconversion_assessment/test_main.py
@@ -173,7 +173,7 @@ def test_main_general_exception(
 # fmt: off
 @patch("__builtin__.open", mock_open(read_data="not json serializable"))
 @patch("scripts.preconversion_assessment_script.setup_convert2rhel", side_effect=Mock())
-@patch("scripts.preconversion_assessment_script.install_convert2rhel", side_effect=Mock())
+@patch("scripts.preconversion_assessment_script.install_convert2rhel", return_value=(True, 1))
 @patch("os.path.exists", return_value=False)
 @patch("scripts.preconversion_assessment_script._check_ini_file_modified", return_value=True)
 @patch("scripts.preconversion_assessment_script.run_convert2rhel", side_effect=Mock())
@@ -204,7 +204,7 @@ def test_main_inhibited_ini_modified(
     assert mock_setup_convert2rhel.call_count == 1
     assert mock_custom_ini.call_count == 1
     assert mock_ini_modified.call_count == 4
-    assert mock_install_convert2rhel.call_count == 0
+    assert mock_install_convert2rhel.call_count == 1
     assert mock_run_convert2rhel.call_count == 0
     assert mock_find_highest_report_level.call_count == 0
     assert mock_gather_textual_report.call_count == 0
@@ -218,7 +218,7 @@ def test_main_inhibited_ini_modified(
 # fmt: off
 @patch("__builtin__.open", mock_open(read_data="not json serializable"))
 @patch("scripts.preconversion_assessment_script.setup_convert2rhel", side_effect=Mock())
-@patch("scripts.preconversion_assessment_script.install_convert2rhel", side_effect=Mock())
+@patch("scripts.preconversion_assessment_script.install_convert2rhel", return_value=(True, 1))
 @patch("os.path.exists", return_value=True)
 @patch("scripts.preconversion_assessment_script.run_convert2rhel", side_effect=Mock())
 @patch("scripts.preconversion_assessment_script.find_highest_report_level", side_effect=Mock(return_value=["SUCCESS"]))
@@ -246,7 +246,7 @@ def test_main_inhibited_custom_ini(
 
     assert mock_setup_convert2rhel.call_count == 1
     assert mock_inhibitor_check.call_count == 4
-    assert mock_install_convert2rhel.call_count == 0
+    assert mock_install_convert2rhel.call_count == 1
     assert mock_run_convert2rhel.call_count == 0
     assert mock_find_highest_report_level.call_count == 0
     assert mock_gather_textual_report.call_count == 0


### PR DESCRIPTION
[HMS-3072](https://issues.redhat.com/browse/HMS-3072)

If custom/modified ini exists on system we need to check only after we are sure convert2rhel is installed as well because we use `rpm -Va convert2rhel` command