### PR TITLE
Fix missing message&JSON in rollback fail in analysis

### DIFF
--- a/scripts/c2r_script.py
+++ b/scripts/c2r_script.py
@@ -692,6 +692,22 @@ def main():
         execution_successful = returncode == 0
         rollback_errors = check_for_inhibitors_in_rollback()
 
+        # Check if there are any inhibitors in the rollback logging. This is
+        # necessary in the case where the analysis was done successfully, but
+        # there was an error in the rollback log.
+        if rollback_errors:
+            raise ProcessError(
+                message=(
+                    "A rollback of changes performed by convert2rhel failed. The system is in an undefined state. "
+                    "Recover the system from a backup or contact Red Hat support."
+                ),
+                report=(
+                    "\nFor details, refer to the convert2rhel log file on the host at "
+                    "/var/log/convert2rhel/convert2rhel.log. Relevant lines from log file: \n%s\n"
+                )
+                % rollback_errors,
+            )
+
         # Returncode other than 0 can happen in two states in analysis mode:
         #  1. In case there is another instance of convert2rhel running
         #  2. In case of KeyboardInterrupt, SystemExit (misplaced by mistaked),
@@ -700,22 +716,6 @@ def main():
         # priority. In case the returncode was non zero, we don't care about
         # the rest and we should jump to the exception handling immediatly
         if not execution_successful:
-            # Check if there are any inhibitors in the rollback logging. This is
-            # necessary in the case where the analysis was done successfully, but
-            # there was an error in the rollback log.
-            if rollback_errors:
-                raise ProcessError(
-                    message=(
-                        "A rollback of changes performed by convert2rhel failed. The system is in an undefined state. "
-                        "Recover the system from a backup or contact Red Hat support."
-                    ),
-                    report=(
-                        "\nFor details, refer to the convert2rhel log file on the host at "
-                        "/var/log/convert2rhel/convert2rhel.log. Relevant lines from log file: \n%s\n"
-                    )
-                    % rollback_errors,
-                )
-
             raise ProcessError(
                 message=(
                     "An error occurred during the pre-conversion analysis. For details, refer to "


### PR DESCRIPTION
HMS-3535

During pre-conversion analysis, if rollback errors occured message was empty and txt report was shown. This PR fixes the conditions to show correct message about error.