### PR TITLE
Improve error when downoad of required file fails

### DIFF
--- a/scripts/c2r_script.py
+++ b/scripts/c2r_script.py
@@ -6,7 +6,7 @@ import subprocess
 import copy
 from time import gmtime, strftime
 
-from urllib2 import urlopen
+from urllib2 import urlopen, URLError
 
 # SCRIPT_TYPE is either 'CONVERSION' or 'ANALYSIS'
 # Value is set in signed yaml envelope in content_vars (SCRIPT_MODE)
@@ -377,9 +377,18 @@ def generate_report_message(highest_status):
 def setup_convert2rhel(required_files):
     """Setup convert2rhel tool by downloading the required files."""
     print("Downloading required files.")
-    for required_file in required_files:
-        required_file.backup()
-        required_file.create_from_host_url_data()
+    try:
+        for required_file in required_files:
+            required_file.backup()
+            required_file.create_from_host_url_data()
+    except URLError as err:
+        url = required_file.host
+        # pylint: disable=raise-missing-from
+        raise ProcessError(
+            message="Failed to download required files needed for convert2rhel to run.",
+            report="Download of required file from %s failed with error: %s"
+            % (url, err),
+        )
 
 
 # Code taken from

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -1,6 +1,9 @@
+import pytest
 from mock import Mock
+from urllib2 import URLError
 
-from scripts.c2r_script import setup_convert2rhel
+
+from scripts.c2r_script import setup_convert2rhel, ProcessError
 
 
 class MockRequiredFile(object):
@@ -22,6 +25,23 @@ def test_setup_calls_backup_and_create_for_every_file():
     required_files = [test_file]
 
     setup_convert2rhel(required_files)
+
+    test_file.backup.assert_called_once()
+    test_file.create_from_host_url_data.assert_called_once()
+
+
+def test_setup_urlerror():
+    # pylint: disable=too-many-arguments
+    mocked_required_file = Mock(spec=MockRequiredFile)
+    test_file = mocked_required_file("/mock/path/file.txt", "foo.bar")
+    test_file.create_from_host_url_data.side_effect = URLError("foo")
+    required_files = [test_file]
+
+    with pytest.raises(ProcessError) as error:
+        setup_convert2rhel(required_files)
+        assert "Download of required file from foo.bar failed with error: foo" in str(
+            error
+        )
 
     test_file.backup.assert_called_once()
     test_file.create_from_host_url_data.assert_called_once()


### PR DESCRIPTION
Fail of urlopen now results in unexpected error, imho would be worth it to report it better.

![image](https://github.com/oamg/convert2rhel-worker-scripts/assets/19702477/1e98e9e1-e626-450f-a6d3-15f1afbe52db)
