### PR TITLE
Update URL for convert2rhel repofile

### DIFF
--- a/scripts/c2r_script.py
+++ b/scripts/c2r_script.py
@@ -650,7 +650,7 @@ def main():
     )
     c2r_repo = RequiredFile(
         path="/etc/yum.repos.d/convert2rhel.repo",
-        host="https://ftp.redhat.com/redhat/convert2rhel/7/convert2rhel.repo",
+        host="https://cdn-public.redhat.com/content/public/addon/dist/convert2rhel/server/7/7Server/x86_64/files/repofile.repo",
     )
     required_files = [
         gpg_key_file,


### PR DESCRIPTION
Use the public CDN for convert2rhel repofile instead of the ftp version.

[HMS-3691](https://issues.redhat.com/browse/HMS-3691)