### PR TITLE
Feat/use all worker variables

### DIFF
--- a/scripts/c2r_script.py
+++ b/scripts/c2r_script.py
@@ -491,10 +491,10 @@ def run_convert2rhel():
     print("Running Convert2RHEL %s" % SCRIPT_TYPE.title())
     env = {"PATH": os.environ["PATH"]}
 
-    if "RHC_WORKER_CONVERT2RHEL_DISABLE_TELEMETRY" in os.environ:
-        env["CONVERT2RHEL_DISABLE_TELEMETRY"] = os.environ[
-            "RHC_WORKER_CONVERT2RHEL_DISABLE_TELEMETRY"
-        ]
+    for key, value in os.environ.items():
+        valid_prefix = "RHC_WORKER_"
+        if key.startswith(valid_prefix):
+            env[key.replace(valid_prefix, "")] = value
 
     command = ["/usr/bin/convert2rhel"]
     if IS_ANALYSIS:

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -5,7 +5,11 @@ from scripts.c2r_script import run_convert2rhel
 
 @patch("scripts.c2r_script.SCRIPT_TYPE", "CONVERSION")
 def test_run_convert2rhel_conversion():
-    mock_env = {"PATH": "/fake/path", "RHC_WORKER_CONVERT2RHEL_DISABLE_TELEMETRY": "1"}
+    mock_env = {
+        "PATH": "/fake/path",
+        "RHC_WORKER_CONVERT2RHEL_DISABLE_TELEMETRY": "1",
+        "RHC_WORKER_FOO": "1",
+    }
 
     with patch("os.environ", mock_env), patch(
         "scripts.c2r_script.run_subprocess", return_value=(b"", 0)
@@ -14,7 +18,11 @@ def test_run_convert2rhel_conversion():
 
     mock_popen.assert_called_once_with(
         ["/usr/bin/convert2rhel", "-y"],
-        env={"PATH": "/fake/path", "CONVERT2RHEL_DISABLE_TELEMETRY": "1"},
+        env={
+            "PATH": "/fake/path",
+            "CONVERT2RHEL_DISABLE_TELEMETRY": "1",
+            "FOO": "1",
+        },
     )
 
 


### PR DESCRIPTION
Since env vars are changing in yaml, new ones can be added and even parameters for task is something that can exist, we can't limit the variables to specific ones in script, it should be safe enough to set all env variables that are prefixed with `RHC_WORKER_*` (they are defined in the yaml downloaded from insights and the worker passes them to script env)