### PR TITLE
Improve environment variable collection from worker

### DIFF
--- a/scripts/c2r_script.py
+++ b/scripts/c2r_script.py
@@ -489,12 +489,12 @@ def run_convert2rhel():
     Run the convert2rhel tool assigning the correct environment variables.
     """
     print("Running Convert2RHEL %s" % SCRIPT_TYPE.title())
-    env = {"PATH": os.environ["PATH"]}
+    env = os.environ
 
-    for key, value in os.environ.items():
+    for key in env:
         valid_prefix = "RHC_WORKER_"
         if key.startswith(valid_prefix):
-            env[key.replace(valid_prefix, "")] = value
+            env[key.replace(valid_prefix, "")] = env.pop(key)
 
     command = ["/usr/bin/convert2rhel"]
     if IS_ANALYSIS:

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -3,6 +3,22 @@ from mock import patch
 from scripts.c2r_script import run_convert2rhel
 
 
+@patch("scripts.c2r_script.SCRIPT_TYPE", "ANALYSIS")
+@patch("scripts.c2r_script.IS_ANALYSIS", True)
+def test_run_convert2rhel_custom_variables():
+    mock_env = {"FOO": "BAR", "BAR": "BAZ", "RHC_WORKER_LALA": "LAND"}
+
+    with patch("os.environ", mock_env), patch(
+        "scripts.c2r_script.run_subprocess", return_value=(b"", 0)
+    ) as mock_popen:
+        run_convert2rhel()
+
+    mock_popen.assert_called_once_with(
+        ["/usr/bin/convert2rhel", "analyze", "-y"],
+        env={"FOO": "BAR", "BAR": "BAZ", "LALA": "LAND"},
+    )
+
+
 @patch("scripts.c2r_script.SCRIPT_TYPE", "CONVERSION")
 def test_run_convert2rhel_conversion():
     mock_env = {


### PR DESCRIPTION
[HMS-3843](https://issues.redhat.com/browse/HMS-3843)

We are making the environment variable collection less strict in the sense that we will start collecting all variables that comes from rhc-worker-script. Meaning that we will trust that what will be passed down to us is trusted and verified.

This will allow convert2rhel to have access to variables that are set in rhcd process and are sent down the way to rhc-worker-script.